### PR TITLE
feat: seed billing defaults and add sandbox user script

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,8 @@
     "prisma": "prisma",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name sprint1_billing_entitlements",
-    "db:seed": "prisma db seed"
+    "db:seed": "prisma db seed",
+    "user:create": "tsx scripts/new-user.ts"
   },
   "dependencies": {
     "@acme/ui": "file:../../packages/ui",

--- a/apps/web/scripts/new-user.ts
+++ b/apps/web/scripts/new-user.ts
@@ -1,0 +1,30 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+function generateDevEmail() {
+  const timestamp = new Date().toISOString().replace(/[-:.TZ]/g, '');
+  return `sandbox+${timestamp}@example.com`;
+}
+
+async function main() {
+  const emailArg = process.argv[2];
+  const email = emailArg ?? generateDevEmail();
+
+  const user = await prisma.user.create({
+    data: {
+      email,
+    },
+  });
+
+  console.log(user.id);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- replace the Prisma seed with idempotent helpers that ensure the subscription and job-post bundles stay active with IRR pricing
- add a sandbox user creation script and wire it into the web app package scripts
- document the seeding workflow and manual billing test plan in the web README

## Testing
- not run (database not configured in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e070cd1dec8327a2691468374c2a95