### PR TITLE
fix: restore next-auth v4 client helpers

### DIFF
--- a/apps/web/lib/auth/config.ts
+++ b/apps/web/lib/auth/config.ts
@@ -1,7 +1,7 @@
 import bcrypt from "bcrypt";
 import Credentials from "next-auth/providers/credentials";
 import type { PrismaClient } from "@prisma/client";
-import type { NextAuthConfig, Session, User } from "next-auth";
+import type { NextAuthOptions, Session, User } from "next-auth";
 import type { AdapterUser } from "next-auth/adapters";
 import type { JWT } from "next-auth/jwt";
 
@@ -28,7 +28,7 @@ type SessionContext = {
   token: JWT;
 };
 
-export function getAuthConfig(prisma: PrismaClient): NextAuthConfig {
+export function getAuthConfig(prisma: PrismaClient): NextAuthOptions {
   return {
     trustHost: true,
     secret: process.env.NEXTAUTH_SECRET,
@@ -120,5 +120,5 @@ export function getAuthConfig(prisma: PrismaClient): NextAuthConfig {
         return session;
       },
     },
-  } satisfies NextAuthConfig;
+  } satisfies NextAuthOptions;
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.446.0",
     "next": "15.0.0-canary.87",
-    "next-auth": "^5.0.0",
+    "next-auth": "^4.24.7",
     "next-themes": "^0.3.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",

--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -1,150 +1,22 @@
+import type { DefaultSession, DefaultUser } from "next-auth";
+import type { JWT as DefaultJWT } from "next-auth/jwt";
+
 declare module "next-auth" {
-  import type { JWT } from "next-auth/jwt";
-  import type { AdapterUser } from "next-auth/adapters";
-
-  export interface User {
-    id: string;
-    email?: string | null;
-    role?: string | null;
-    [key: string]: unknown;
-  }
-
-  export interface Session {
-    user?: User & {
+  interface Session extends DefaultSession {
+    user?: DefaultSession["user"] & {
       id?: string;
-      email?: string | null;
-      role?: string | null;
-    };
-    expires?: string;
-    [key: string]: unknown;
-  }
-
-  export interface NextAuthConfig {
-    trustHost?: boolean;
-    secret?: string;
-    session?: {
-      strategy?: string;
-    };
-    pages?: {
-      signIn?: string;
-      [key: string]: string | undefined;
-    };
-    providers?: Array<unknown>;
-    callbacks?: {
-      jwt?: (context: { token: JWT; user?: AdapterUser | User | null }) =>
-        | Promise<JWT>
-        | JWT;
-      session?: (context: {
-        session: Session;
-        token: JWT;
-        user?: AdapterUser | User | null;
-      }) => Promise<Session> | Session;
+      role?: "USER" | "ADMIN";
     };
   }
 
-  export type NextAuthOptions = NextAuthConfig;
-
-  export function getServerSession(
-    ...args:
-      | []
-      | [config: NextAuthConfig]
-      | [request: Request, response: Response, config: NextAuthConfig]
-  ): Promise<Session | null>;
-
-  export default function NextAuth(
-    config: NextAuthConfig
-  ): {
-    GET: (request: Request) => Promise<Response> | Response;
-    POST: (request: Request) => Promise<Response> | Response;
-  } & ((request: Request) => Promise<Response> | Response);
-}
-
-declare module "next-auth/react" {
-  import type { Session } from "next-auth";
-
-  export interface SignInResponse {
-    error?: string | null;
-    ok?: boolean;
-    status?: number;
-    url?: string | null;
-      }
-
-  export type SignInOptions = Record<string, unknown> & {
-    callbackUrl?: string;
-    redirect?: boolean;
-    email?: string;
-    password?: string;
-  };
-
-  export function signIn(
-    provider: string,
-    options?: SignInOptions,
-    authorizationParams?: Record<string, unknown>
-  ): Promise<SignInResponse | undefined>;
-
-  export function signOut(options?: { callbackUrl?: string }): Promise<void>;
-
-
-  export function useSession(): { data: Session | null; status: "loading" | "authenticated" | "unauthenticated" };
-
-}
-
-declare module "next-auth/providers/credentials" {
-  import type { NextAuthConfig } from "next-auth";
-
-  export type CredentialsConfig = {
-    name?: string;
-    credentials?: Record<string, { label?: string; type?: string }>;
-    authorize?: (credentials: Record<string, unknown>) =>
-      | Record<string, unknown>
-      | null
-      | Promise<Record<string, unknown> | null>;
-  };
-
-  export default function Credentials(
-    options: CredentialsConfig
-  ): NextAuthConfig["providers"] extends Array<infer Provider>
-    ? Provider
-    : unknown;
-}
-
-declare module "next-auth/adapters" {
-  export interface AdapterUser {
-    id: string;
-    email?: string | null;
-    emailVerified?: Date | null;
-    name?: string | null;
-    image?: string | null;
-    [key: string]: unknown;
+  interface User extends DefaultUser {
+    role?: "USER" | "ADMIN";
   }
 }
 
 declare module "next-auth/jwt" {
-  import type { NextRequest } from "next/server";
-
-  export interface JWT {
+  interface JWT extends DefaultJWT {
     id?: string | number;
-    email?: string | null;
-    role?: string | null;
-    name?: string | null;
-    picture?: string | null;
-    [key: string]: unknown;
+    role?: "USER" | "ADMIN";
   }
-  export interface GetTokenParams {
-    req: NextRequest | (Request & { cookies?: Record<string, string> });
-    secret?: string;
-  }
-
-  export function getToken(params: GetTokenParams): Promise<JWT | null>;
-}
-
-declare module "bcrypt" {
-  export function hash(data: string, saltOrRounds: string | number): Promise<string>;
-  export function compare(data: string, encrypted: string): Promise<boolean>;
-  export function genSalt(rounds?: number): Promise<string>;
-  export default {
-    hash,
-    compare,
-    genSalt,
-  };
 }


### PR DESCRIPTION
## Summary
- downgrade @app/web to next-auth v4 so the React client helpers resolve correctly
- align the authentication config with NextAuthOptions from v4
- replace the handwritten next-auth type stubs with targeted module augmentation for session and JWT fields

## Testing
- pnpm -F @app/web lint *(fails: blocked from downloading pnpm due to network proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e157c5cfa4832787faf0d6d244ab6a