### PR TITLE
feat: add dashboard shell with settings forms

### DIFF
--- a/apps/web/app/dashboard/_components/sidebar-nav.tsx
+++ b/apps/web/app/dashboard/_components/sidebar-nav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { Route } from "next";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+type SidebarItem = {
+  href: Route;
+  label: string;
+};
+
+type SidebarNavProps = {
+  items: SidebarItem[];
+};
+
+export function DashboardSidebarNav({ items }: SidebarNavProps) {
+  const pathname = usePathname();
+
+  return (
+    <nav className="space-y-1 text-sm font-medium">
+      {items.map((item) => {
+        const isActive = pathname === item.href || pathname?.startsWith(`${item.href}/`);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "flex items-center justify-between rounded-md px-3 py-2 transition",
+              isActive
+                ? "bg-primary/10 text-primary hover:bg-primary/20"
+                : "text-foreground hover:bg-muted"
+            )}
+          >
+            <span>{item.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,37 +1,39 @@
 import type { ReactNode } from "react";
 import type { Route } from "next";
-import Link from "next/link";
+
+import { DashboardSidebarNav } from "./_components/sidebar-nav";
 
 const dashboardNav = [
+  { href: "/dashboard/profile" as Route, label: "پروفایل" },
   { href: "/dashboard/billing" as Route, label: "صورتحساب" },
-] satisfies Array<{  href: Route;
-  label: string;
-}>;
+  { href: "/dashboard/settings" as Route, label: "تنظیمات" },
+] satisfies Array<{ href: Route; label: string }>;
+
 export default function DashboardLayout({
   children,
 }: {
   children: ReactNode;
 }) {
   return (
-    <div dir="rtl" className="min-h-screen bg-muted/20">
+    <div className="min-h-screen bg-muted/20" dir="rtl">
       <div className="flex min-h-screen flex-row-reverse">
-        <aside className="w-64 border-l border-border bg-background p-6">
-          <div className="text-xl font-semibold">داشبورد</div>
-          <nav className="mt-6 space-y-2 text-sm">
-            {dashboardNav.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="flex rounded-md px-3 py-2 font-medium text-foreground transition hover:bg-muted"
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
+        <aside className="w-full max-w-xs border-l border-border bg-background p-6">
+          <div className="space-y-6">
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-muted-foreground">
+                مدیریت حساب
+              </p>
+              <h2 className="text-xl font-semibold">پنل کاربری</h2>
+            </div>
+            <DashboardSidebarNav items={dashboardNav} />
+          </div>
         </aside>
-        <main className="flex-1">
-          <header className="border-b border-border bg-background p-6">
+        <main className="flex-1 border-l border-border/60 bg-background">
+          <header className="border-b border-border bg-background/90 px-6 py-4">
             <h1 className="text-2xl font-semibold">داشبورد</h1>
+            <p className="text-sm text-muted-foreground">
+              از این بخش می‌توانید اطلاعات حساب خود را مدیریت کنید.
+            </p>
           </header>
           <div className="p-6">{children}</div>
         </main>

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { getServerAuthSession } from "@/lib/auth/session";
+
+const quickLinks = [
+  { href: "/dashboard/profile", label: "پروفایل", description: "اطلاعات فردی و حرفه‌ای" },
+  { href: "/dashboard/billing", label: "صورتحساب", description: "اشتراک‌ها و پرداخت‌ها" },
+  { href: "/dashboard/settings", label: "تنظیمات", description: "نام و رمز عبور" },
+];
+
+export default async function DashboardPage() {
+  const session = await getServerAuthSession();
+  const email = session?.user?.email ?? "—";
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-2">
+        <h2 className="text-2xl font-semibold">خوش آمدید</h2>
+        <p className="text-sm text-muted-foreground">
+          در این بخش می‌توانید وضعیت حساب خود را دنبال کرده و به تنظیمات مهم دسترسی پیدا کنید.
+        </p>
+      </section>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>اطلاعات ورود</CardTitle>
+          <CardDescription>آدرس ایمیل شما برای ورود و اعلان‌ها استفاده می‌شود.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-1 text-sm">
+            <span className="text-muted-foreground">ایمیل</span>
+            <div className="rounded-md border border-dashed bg-muted/50 px-3 py-2 font-medium" dir="ltr">
+              {email}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {quickLinks.map((item) => (
+          <Card key={item.href}>
+            <CardHeader>
+              <CardTitle className="text-lg">{item.label}</CardTitle>
+              <CardDescription>{item.description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild className="w-full" variant="secondary">
+                <Link href={item.href}>{item.label}</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/profile/page.tsx
+++ b/apps/web/app/dashboard/profile/page.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function ProfilePage() {
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>پروفایل کاربری</CardTitle>
+          <CardDescription>
+            ویرایش پروفایل در فاز بعدی اضافه می‌شود. در حال حاضر می‌توانید سایر بخش‌های پنل را بررسی کنید.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-3">
+            <Button variant="secondary" disabled>
+              تکمیل اطلاعات پایه
+            </Button>
+            <Button variant="outline" disabled>
+              افزودن نمونه‌کار
+            </Button>
+            <Button variant="ghost" disabled>
+              مدیریت شبکه‌های اجتماعی
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/settings/_components/account-info-form.tsx
+++ b/apps/web/app/dashboard/settings/_components/account-info-form.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/use-toast";
+
+import { updateName } from "../actions";
+
+type AccountInfoFormProps = {
+  initialName?: string;
+  email: string;
+};
+
+export function AccountInfoForm({ initialName = "", email }: AccountInfoFormProps) {
+  const [name, setName] = useState(initialName);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const { toast } = useToast();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+    const sanitizedName = name.trim();
+    formData.set("name", sanitizedName);
+
+    startTransition(() => {
+      updateName(formData)
+        .then((result) => {
+          if (result?.ok) {
+            setError(null);
+            setName(sanitizedName);
+            toast({
+              title: "اطلاعات حساب به‌روزرسانی شد.",
+              description: "نام شما با موفقیت ذخیره شد.",
+            });
+          } else {
+            setError(result?.error ?? "خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+          }
+        })
+        .catch(() => {
+          setError("خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+        });
+    });
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      <div className="space-y-2">
+        <Label className="text-sm font-medium text-muted-foreground">ایمیل</Label>
+        <div
+          className="rounded-md border border-dashed bg-muted/50 px-3 py-2 text-sm"
+          dir="ltr"
+        >
+          {email}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          تغییر ایمیل در حال حاضر امکان‌پذیر نیست.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="name">نام و نام خانوادگی</Label>
+        <Input
+          id="name"
+          name="name"
+          value={name}
+          onChange={(event) => {
+            if (error) {
+              setError(null);
+            }
+            setName(event.target.value);
+          }}
+          placeholder="نام خود را وارد کنید"
+          autoComplete="name"
+          maxLength={191}
+          required
+          disabled={isPending}
+        />
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="flex items-center justify-end">
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "در حال ذخیره..." : "ذخیره تغییرات"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/dashboard/settings/_components/password-change-form.tsx
+++ b/apps/web/app/dashboard/settings/_components/password-change-form.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import type { ChangeEvent, FormEvent } from "react";
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/use-toast";
+
+import { changePassword } from "../actions";
+
+type PasswordFormState = {
+  currentPassword: string;
+  newPassword: string;
+  confirmNewPassword: string;
+};
+
+const INITIAL_STATE: PasswordFormState = {
+  currentPassword: "",
+  newPassword: "",
+  confirmNewPassword: "",
+};
+
+export function PasswordChangeForm() {
+  const [values, setValues] = useState<PasswordFormState>(INITIAL_STATE);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const { toast } = useToast();
+
+  const updateField = (field: keyof PasswordFormState) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setValues((prev) => ({ ...prev, [field]: event.target.value }));
+      if (error) {
+        setError(null);
+      }
+    };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    startTransition(() => {
+      changePassword(formData)
+        .then((result) => {
+          if (result?.ok) {
+            setError(null);
+            setValues(INITIAL_STATE);
+            form.reset();
+            toast({
+              title: "رمز عبور با موفقیت تغییر کرد.",
+              description: "برای ورود بعدی از رمز جدید استفاده کنید.",
+            });
+          } else {
+            setError(result?.error ?? "خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+          }
+        })
+        .catch(() => {
+          setError("خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+        });
+    });
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2 md:col-span-2">
+          <Label htmlFor="currentPassword">رمز عبور فعلی</Label>
+          <Input
+            id="currentPassword"
+            name="currentPassword"
+            type="password"
+            dir="ltr"
+            value={values.currentPassword}
+            onChange={updateField("currentPassword")}
+            autoComplete="current-password"
+            required
+            disabled={isPending}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="newPassword">رمز عبور جدید</Label>
+          <Input
+            id="newPassword"
+            name="newPassword"
+            type="password"
+            dir="ltr"
+            value={values.newPassword}
+            onChange={updateField("newPassword")}
+            autoComplete="new-password"
+            minLength={8}
+            required
+            disabled={isPending}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="confirmNewPassword">تکرار رمز عبور جدید</Label>
+          <Input
+            id="confirmNewPassword"
+            name="confirmNewPassword"
+            type="password"
+            dir="ltr"
+            value={values.confirmNewPassword}
+            onChange={updateField("confirmNewPassword")}
+            autoComplete="new-password"
+            minLength={8}
+            required
+            disabled={isPending}
+          />
+        </div>
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="flex items-center justify-end">
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "در حال تغییر..." : "ذخیره رمز عبور"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/dashboard/settings/actions.ts
+++ b/apps/web/app/dashboard/settings/actions.ts
@@ -1,0 +1,124 @@
+"use server";
+
+import bcrypt from "bcryptjs";
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/lib/prisma";
+import { getServerAuthSession } from "@/lib/auth/session";
+import { nameSchema, passwordChangeSchema } from "@/lib/validation/user";
+
+type ActionResult = {
+  ok: boolean;
+  error?: string;
+};
+
+const SETTINGS_PATHS: Array<string> = [
+  "/dashboard",
+  "/dashboard/settings",
+];
+
+const AUTH_ERROR_MESSAGE = "نشست شما منقضی شده است. لطفاً دوباره وارد شوید.";
+const GENERIC_ERROR_MESSAGE = "خطایی رخ داد. لطفاً دوباره تلاش کنید.";
+
+async function ensureSessionUser() {
+  const session = await getServerAuthSession();
+
+  if (!session?.user?.id) {
+    throw new Error(AUTH_ERROR_MESSAGE);
+  }
+
+  return session.user.id;
+}
+
+async function revalidateSettings() {
+  for (const path of SETTINGS_PATHS) {
+    revalidatePath(path);
+  }
+}
+
+export async function updateName(formData: FormData): Promise<ActionResult> {
+  try {
+    const userId = await ensureSessionUser();
+    const rawName = formData.get("name");
+    const parsed = nameSchema.safeParse(typeof rawName === "string" ? rawName : "");
+
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      return {
+        ok: false,
+        error: issue?.message ?? GENERIC_ERROR_MESSAGE,
+      };
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { name: parsed.data },
+    });
+
+    await revalidateSettings();
+
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof Error && error.message === AUTH_ERROR_MESSAGE) {
+      return { ok: false, error: AUTH_ERROR_MESSAGE };
+    }
+
+    console.error("updateName", error);
+    return { ok: false, error: GENERIC_ERROR_MESSAGE };
+  }
+}
+
+export async function changePassword(formData: FormData): Promise<ActionResult> {
+  try {
+    const userId = await ensureSessionUser();
+
+    const parsed = passwordChangeSchema.safeParse({
+      currentPassword: formData.get("currentPassword") ?? "",
+      newPassword: formData.get("newPassword") ?? "",
+      confirmNewPassword: formData.get("confirmNewPassword") ?? "",
+    });
+
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      return {
+        ok: false,
+        error: issue?.message ?? GENERIC_ERROR_MESSAGE,
+      };
+    }
+
+    const { currentPassword, newPassword } = parsed.data;
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { passwordHash: true },
+    });
+
+    if (!user?.passwordHash) {
+      return { ok: false, error: GENERIC_ERROR_MESSAGE };
+    }
+
+    const isValid = await bcrypt.compare(currentPassword, user.passwordHash);
+
+    if (!isValid) {
+      return { ok: false, error: "رمز عبور فعلی نادرست است." };
+    }
+
+    const passwordHash = await bcrypt.hash(newPassword, 12);
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { passwordHash },
+    });
+
+    await revalidateSettings();
+
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof Error && error.message === AUTH_ERROR_MESSAGE) {
+      return { ok: false, error: AUTH_ERROR_MESSAGE };
+    }
+
+    console.error("changePassword", error);
+    return { ok: false, error: GENERIC_ERROR_MESSAGE };
+  }
+}

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -1,0 +1,64 @@
+import { redirect } from "next/navigation";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { prisma } from "@/lib/prisma";
+import { getServerAuthSession } from "@/lib/auth/session";
+
+import { AccountInfoForm } from "./_components/account-info-form";
+import { PasswordChangeForm } from "./_components/password-change-form";
+
+export default async function SettingsPage() {
+  const session = await getServerAuthSession();
+
+  const userId = session?.user?.id;
+
+  if (!userId) {
+    redirect("/auth/signin");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      name: true,
+      email: true,
+    },
+  });
+
+  if (!user?.email) {
+    redirect("/auth/signin");
+  }
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>اطلاعات حساب</CardTitle>
+          <CardDescription>
+            نام نمایشی خود را ویرایش کنید. تغییر ایمیل در حال حاضر امکان‌پذیر نیست.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AccountInfoForm initialName={user.name ?? ""} email={user.email} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>تغییر رمز عبور</CardTitle>
+          <CardDescription>
+            برای امنیت بیشتر، رمز عبور فعلی خود را وارد کرده و رمز جدیدی با حداقل ۸ کاراکتر انتخاب کنید.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <PasswordChangeForm />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -1,0 +1,9 @@
+import { getServerSession } from "next-auth";
+
+import { prisma } from "@/lib/prisma";
+
+import { getAuthConfig } from "./config";
+
+export async function getServerAuthSession() {
+  return getServerSession(getAuthConfig(prisma));
+}

--- a/apps/web/lib/validation/user.ts
+++ b/apps/web/lib/validation/user.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const nameSchema = z
+  .string({ required_error: "لطفاً نام را وارد کنید." })
+  .trim()
+  .min(1, { message: "لطفاً نام را وارد کنید." })
+  .max(191, { message: "نام نباید بیش از ۱۹۱ کاراکتر باشد." });
+
+export const passwordChangeSchema = z
+  .object({
+    currentPassword: z
+      .string({ required_error: "لطفاً رمز عبور فعلی را وارد کنید." })
+      .min(1, { message: "لطفاً رمز عبور فعلی را وارد کنید." }),
+    newPassword: z
+      .string({ required_error: "رمز عبور باید حداقل ۸ کاراکتر باشد." })
+      .min(8, { message: "رمز عبور باید حداقل ۸ کاراکتر باشد." }),
+    confirmNewPassword: z
+      .string({ required_error: "رمز عبور باید حداقل ۸ کاراکتر باشد." })
+      .min(8, { message: "رمز عبور باید حداقل ۸ کاراکتر باشد." }),
+  })
+  .refine((data) => data.newPassword === data.confirmNewPassword, {
+    message: "تأیید رمز عبور مطابق نیست.",
+    path: ["confirmNewPassword"],
+  });
+
+export type PasswordChangeInput = z.infer<typeof passwordChangeSchema>;


### PR DESCRIPTION
## Summary
- build a reusable داشبورد layout with ناوبری جانبی و صفحه نمای کلی
- اضافه کردن صفحات پروفایل، صورتحساب و تنظیمات با محتوای راست به چپ
- پیاده‌سازی اکشن‌های سرور برای ویرایش نام و تغییر رمز عبور با اعتبارسنجی zod

## Testing
- pnpm --filter @app/web lint *(fails: registry fetch blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b386a4348327a791f180dd86527d