### PR TITLE
feat: add profile entity and public directory

### DIFF
--- a/apps/web/app/dashboard/profile/_components/media-gallery.tsx
+++ b/apps/web/app/dashboard/profile/_components/media-gallery.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useState, useTransition } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+
+import { deleteImage, uploadImage } from "../actions";
+
+type GalleryImage = {
+  url: string;
+};
+
+type MediaGalleryProps = {
+  images: GalleryImage[];
+};
+
+export function MediaGallery({ images }: MediaGalleryProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [uploadInputKey, setUploadInputKey] = useState<number>(Date.now());
+
+  const handleUpload = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const file = formData.get("file");
+    if (!(file instanceof File) || file.size === 0) {
+      setError("لطفاً یک تصویر انتخاب کنید.");
+      return;
+    }
+
+    startTransition(() => {
+      uploadImage(formData)
+        .then((result) => {
+          if (result.ok) {
+            setError(null);
+            setUploadInputKey(Date.now());
+            form.reset();
+            toast({
+              title: "تصویر بارگذاری شد.",
+              description: "گالری با موفقیت به‌روزرسانی شد.",
+            });
+            router.refresh();
+          } else {
+            setError(result.error ?? "خطایی رخ داد.");
+          }
+        })
+        .catch(() => {
+          setError("خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+        });
+    });
+  };
+
+  const handleDelete = (url: string) => {
+    const formData = new FormData();
+    formData.set("url", url);
+
+    startTransition(() => {
+      deleteImage(formData)
+        .then((result) => {
+          if (result.ok) {
+            setError(null);
+            toast({
+              title: "تصویر حذف شد.",
+              description: "گالری به‌روزرسانی شد.",
+            });
+            router.refresh();
+          } else {
+            setError(result.error ?? "خطایی رخ داد.");
+          }
+        })
+        .catch(() => {
+          setError("خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+        });
+    });
+  };
+
+  return (
+    <div className="space-y-6" dir="rtl">
+      <form className="space-y-4" onSubmit={handleUpload}>
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="gallery-file">
+            افزودن تصویر جدید
+          </label>
+          <input
+            key={uploadInputKey}
+            id="gallery-file"
+            name="file"
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            disabled={isPending}
+            dir="ltr"
+            className="block w-full text-sm"
+          />
+        </div>
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        <div className="flex items-center justify-end">
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "در حال بارگذاری..." : "آپلود تصویر"}
+          </Button>
+        </div>
+      </form>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {images.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            هنوز تصویری در گالری ثبت نشده است.
+          </p>
+        ) : (
+          images.map((image) => (
+            <div
+              key={image.url}
+              className="space-y-3 rounded-md border border-border p-3 shadow-sm"
+            >
+              <div className="overflow-hidden rounded-md border border-border/50">
+                <Image
+                  src={image.url}
+                  alt="تصویر گالری"
+                  width={400}
+                  height={280}
+                  className="h-48 w-full object-cover"
+                />
+              </div>
+              <p className="truncate text-xs text-muted-foreground" dir="ltr">
+                {image.url}
+              </p>
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  disabled={isPending}
+                  onClick={() => handleDelete(image.url)}
+                >
+                  حذف تصویر
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/profile/_components/personal-info-form.tsx
+++ b/apps/web/app/dashboard/profile/_components/personal-info-form.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import type { ChangeEvent, FormEvent } from "react";
+import { useState, useTransition } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import type { City } from "@/lib/location/cities";
+
+import { upsertPersonalInfo } from "../actions";
+
+type PersonalInfoFormValues = {
+  firstName: string;
+  lastName: string;
+  stageName: string;
+  age: string;
+  phone: string;
+  address: string;
+  cityId: string;
+  avatarUrl: string;
+  bio: string;
+};
+
+type FieldErrors = Partial<Record<keyof PersonalInfoFormValues, string>>;
+
+type PersonalInfoFormProps = {
+  cities: City[];
+  initialValues: {
+    firstName?: string | null;
+    lastName?: string | null;
+    stageName?: string | null;
+    age?: number | null;
+    phone?: string | null;
+    address?: string | null;
+    cityId?: string | null;
+    avatarUrl?: string | null;
+    bio?: string | null;
+  };
+};
+
+export function PersonalInfoForm({ cities, initialValues }: PersonalInfoFormProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+  const [values, setValues] = useState<PersonalInfoFormValues>({
+    firstName: initialValues.firstName ?? "",
+    lastName: initialValues.lastName ?? "",
+    stageName: initialValues.stageName ?? "",
+    age: initialValues.age ? String(initialValues.age) : "",
+    phone: initialValues.phone ?? "",
+    address: initialValues.address ?? "",
+    cityId: initialValues.cityId ?? "",
+    avatarUrl: initialValues.avatarUrl ?? "",
+    bio: initialValues.bio ?? "",
+  });
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const updateValue = (field: keyof PersonalInfoFormValues) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const nextValue = event.target.value;
+      setValues((prev) => ({ ...prev, [field]: nextValue }));
+      setFieldErrors((prev) => ({ ...prev, [field]: undefined }));
+      setFormError(null);
+    };
+
+  const handleCityChange = (cityId: string) => {
+    setValues((prev) => ({ ...prev, cityId }));
+    setFieldErrors((prev) => ({ ...prev, cityId: undefined }));
+    setFormError(null);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    formData.set("firstName", values.firstName.trim());
+    formData.set("lastName", values.lastName.trim());
+    formData.set("stageName", values.stageName.trim());
+    formData.set("age", values.age.trim());
+    formData.set("phone", values.phone.trim());
+    formData.set("address", values.address.trim());
+    formData.set("cityId", values.cityId.trim());
+    formData.set("bio", values.bio.trim());
+    formData.set("avatarUrl", values.avatarUrl.trim());
+
+    startTransition(() => {
+      upsertPersonalInfo(formData)
+        .then((result) => {
+          if (result.ok) {
+            setFieldErrors({});
+            setFormError(null);
+            if (result.data?.avatarUrl) {
+              setValues((prev) => ({ ...prev, avatarUrl: result.data?.avatarUrl ?? "" }));
+            }
+            toast({
+              title: "اطلاعات پروفایل ذخیره شد.",
+              description: "اطلاعات فردی با موفقیت به‌روزرسانی شد.",
+            });
+            router.refresh();
+          } else {
+            setFieldErrors(result.fieldErrors ?? {});
+            setFormError(result.error ?? null);
+          }
+        })
+        .catch(() => {
+          setFormError("خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+        });
+    });
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      <input type="hidden" name="avatarUrl" value={values.avatarUrl} />
+
+      <div className="grid gap-4 md:grid-cols-2" dir="rtl">
+        <div className="space-y-2">
+          <Label htmlFor="firstName">نام</Label>
+          <Input
+            id="firstName"
+            name="firstName"
+            value={values.firstName}
+            onChange={updateValue("firstName")}
+            maxLength={191}
+            required
+            disabled={isPending}
+            placeholder="نام خود را وارد کنید"
+          />
+          {fieldErrors.firstName ? (
+            <p className="text-sm text-destructive">{fieldErrors.firstName}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="lastName">نام خانوادگی</Label>
+          <Input
+            id="lastName"
+            name="lastName"
+            value={values.lastName}
+            onChange={updateValue("lastName")}
+            maxLength={191}
+            required
+            disabled={isPending}
+            placeholder="نام خانوادگی خود را وارد کنید"
+          />
+          {fieldErrors.lastName ? (
+            <p className="text-sm text-destructive">{fieldErrors.lastName}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="stageName">نام مستعار (اختیاری)</Label>
+          <Input
+            id="stageName"
+            name="stageName"
+            value={values.stageName}
+            onChange={updateValue("stageName")}
+            maxLength={191}
+            disabled={isPending}
+            placeholder="مثلاً نام هنری"
+          />
+          {fieldErrors.stageName ? (
+            <p className="text-sm text-destructive">{fieldErrors.stageName}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="age">سن</Label>
+          <Input
+            id="age"
+            name="age"
+            type="number"
+            min={5}
+            max={120}
+            value={values.age}
+            onChange={updateValue("age")}
+            required
+            disabled={isPending}
+            placeholder="سن"
+          />
+          {fieldErrors.age ? (
+            <p className="text-sm text-destructive">{fieldErrors.age}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="phone">شماره تلفن</Label>
+          <Input
+            id="phone"
+            name="phone"
+            value={values.phone}
+            onChange={updateValue("phone")}
+            inputMode="numeric"
+            dir="ltr"
+            pattern="0\\d{9}"
+            maxLength={10}
+            minLength={10}
+            required
+            disabled={isPending}
+            placeholder="0XXXXXXXXX"
+          />
+          <CardDescription className="text-xs text-muted-foreground">
+            این شماره به صورت عمومی نمایش داده نمی‌شود.
+          </CardDescription>
+          {fieldErrors.phone ? (
+            <p className="text-sm text-destructive">{fieldErrors.phone}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="address">آدرس (غیرقابل نمایش عمومی)</Label>
+          <Input
+            id="address"
+            name="address"
+            value={values.address}
+            onChange={updateValue("address")}
+            maxLength={1000}
+            disabled={isPending}
+            placeholder="نشانی محل سکونت یا کار"
+          />
+          {fieldErrors.address ? (
+            <p className="text-sm text-destructive">{fieldErrors.address}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="cityId">شهر</Label>
+          <Select
+            value={values.cityId}
+            onValueChange={handleCityChange}
+            disabled={isPending || cities.length === 0}
+            name="cityId"
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="شهر خود را انتخاب کنید" />
+            </SelectTrigger>
+            <SelectContent>
+              {cities.length === 0 ? (
+                <SelectItem disabled value="">
+                  به‌زودی لیست شهرها تکمیل می‌شود
+                </SelectItem>
+              ) : null}
+              {cities.map((city) => (
+                <SelectItem key={city.id} value={city.id}>
+                  {city.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <input type="hidden" name="cityId" value={values.cityId} />
+          {fieldErrors.cityId ? (
+            <p className="text-sm text-destructive">{fieldErrors.cityId}</p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <Label htmlFor="avatar">تصویر پروفایل</Label>
+        {values.avatarUrl ? (
+          <div className="flex flex-col items-start gap-2">
+            <div className="overflow-hidden rounded-md border">
+              <Image
+                src={values.avatarUrl}
+                alt="پیش‌نمایش تصویر پروفایل"
+                width={160}
+                height={160}
+                className="h-40 w-40 object-cover"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground" dir="ltr">
+              {values.avatarUrl}
+            </p>
+          </div>
+        ) : null}
+        <Input
+          id="avatar"
+          name="avatar"
+          type="file"
+          accept="image/png,image/jpeg,image/webp"
+          disabled={isPending}
+          dir="ltr"
+        />
+        {fieldErrors.avatarUrl ? (
+          <p className="text-sm text-destructive">{fieldErrors.avatarUrl}</p>
+        ) : null}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="bio">بیوگرافی (اختیاری)</Label>
+        <Textarea
+          id="bio"
+          name="bio"
+          value={values.bio}
+          onChange={updateValue("bio")}
+          maxLength={2000}
+          rows={5}
+          disabled={isPending}
+          placeholder="درباره خود بنویسید"
+        />
+        {fieldErrors.bio ? (
+          <p className="text-sm text-destructive">{fieldErrors.bio}</p>
+        ) : null}
+      </div>
+
+      {formError ? <p className="text-sm text-destructive">{formError}</p> : null}
+
+      <div className="flex items-center justify-end gap-3">
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "در حال ذخیره..." : "ذخیره اطلاعات"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/dashboard/profile/_components/publish-panel.tsx
+++ b/apps/web/app/dashboard/profile/_components/publish-panel.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+
+import { publishProfile, unpublishProfile } from "../actions";
+
+type PersonalInfoSummary = {
+  firstName?: string | null;
+  lastName?: string | null;
+  stageName?: string | null;
+  age?: number | null;
+  phone?: string | null;
+  address?: string | null;
+  cityName?: string | null;
+  bio?: string | null;
+};
+
+type PublishPanelProps = {
+  canPublish: boolean;
+  isPublished: boolean;
+  readinessIssues: string[];
+  personalInfo: PersonalInfoSummary;
+};
+
+export function PublishPanel({
+  canPublish,
+  isPublished,
+  readinessIssues,
+  personalInfo,
+}: PublishPanelProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<string[]>([]);
+
+  const readyToPublish = readinessIssues.length === 0;
+
+  const fullName = useMemo(() => {
+    const first = personalInfo.firstName ?? "";
+    const last = personalInfo.lastName ?? "";
+    const stage = personalInfo.stageName?.trim();
+    if (stage) {
+      return `${stage}`;
+    }
+    return `${first} ${last}`.trim();
+  }, [personalInfo.firstName, personalInfo.lastName, personalInfo.stageName]);
+
+  const handlePublish = () => {
+    setError(null);
+    setFieldErrors([]);
+    startTransition(() => {
+      publishProfile()
+        .then((result) => {
+          if (result.ok) {
+            toast({
+              title: "پروفایل منتشر شد.",
+              description: "پروفایل شما اکنون برای عموم قابل مشاهده است.",
+            });
+            router.refresh();
+          } else {
+            setError(result.error ?? null);
+            if (result.fieldErrors) {
+              const issues = Object.values(result.fieldErrors).filter(Boolean) as string[];
+              setFieldErrors(issues);
+            }
+          }
+        })
+        .catch(() => {
+          setError("خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+        });
+    });
+  };
+
+  const handleUnpublish = () => {
+    setError(null);
+    setFieldErrors([]);
+    startTransition(() => {
+      unpublishProfile()
+        .then((result) => {
+          if (result.ok) {
+            toast({
+              title: "پروفایل لغو انتشار شد.",
+              description: "پروفایل شما دیگر به‌صورت عمومی نمایش داده نمی‌شود.",
+            });
+            router.refresh();
+          } else {
+            setError(result.error ?? null);
+          }
+        })
+        .catch(() => {
+          setError("خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+        });
+    });
+  };
+
+  return (
+    <div className="space-y-6" dir="rtl">
+      <div className="flex flex-wrap items-center gap-3">
+        <Badge variant={isPublished ? "default" : "secondary"} className="px-3 py-1">
+          {isPublished ? "منتشر شده" : "پیش‌نویس"}
+        </Badge>
+        <Badge variant={readyToPublish ? "success" : "destructive"} className="px-3 py-1">
+          {readyToPublish ? "آماده انتشار" : "نیازمند تکمیل اطلاعات"}
+        </Badge>
+        <Badge variant={canPublish ? "outline" : "destructive"} className="px-3 py-1">
+          {canPublish ? "اشتراک فعال" : "بدون اشتراک"}
+        </Badge>
+      </div>
+
+      <div className="space-y-3 text-sm leading-7 text-muted-foreground">
+        <p>
+          <span className="font-semibold text-foreground">نام نمایشی: </span>
+          {fullName || "نامشخص"}
+        </p>
+        <p>
+          <span className="font-semibold text-foreground">سن: </span>
+          {personalInfo.age ?? "نامشخص"}
+        </p>
+        <p>
+          <span className="font-semibold text-foreground">شهر: </span>
+          {personalInfo.cityName ?? "نامشخص"}
+        </p>
+        <p>
+          <span className="font-semibold text-foreground">شماره تماس (خصوصی): </span>
+          {personalInfo.phone ?? "نامشخص"}
+        </p>
+        <p>
+          <span className="font-semibold text-foreground">آدرس (خصوصی): </span>
+          {personalInfo.address ?? "نامشخص"}
+        </p>
+        {personalInfo.bio ? (
+          <p>
+            <span className="font-semibold text-foreground">بیوگرافی: </span>
+            {personalInfo.bio}
+          </p>
+        ) : null}
+      </div>
+
+      {readinessIssues.length > 0 ? (
+        <div className="space-y-2 rounded-md border border-yellow-400/60 bg-yellow-100/60 p-4 text-sm text-yellow-900">
+          <p className="font-semibold">برای انتشار، موارد زیر را تکمیل کنید:</p>
+          <ul className="list-disc space-y-1 pr-5">
+            {readinessIssues.map((issue, index) => (
+              <li key={`${issue}-${index}`}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {fieldErrors.length > 0 ? (
+        <div className="space-y-1 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {fieldErrors.map((message, index) => (
+            <p key={`${message}-${index}`}>{message}</p>
+          ))}
+        </div>
+      ) : null}
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="flex flex-wrap gap-3">
+        <Button
+          type="button"
+          onClick={handlePublish}
+          disabled={isPending || !canPublish || !readyToPublish}
+        >
+          {isPending ? "در حال پردازش..." : "انتشار پروفایل"}
+        </Button>
+        {isPublished ? (
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={isPending}
+            onClick={handleUnpublish}
+          >
+            لغو انتشار
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/profile/_components/publish-status-banner.tsx
+++ b/apps/web/app/dashboard/profile/_components/publish-status-banner.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+
+import { unpublishProfile } from "../actions";
+
+type PublishStatusBannerProps = {
+  canPublish: boolean;
+  isPublished: boolean;
+};
+
+export function PublishStatusBanner({
+  canPublish,
+  isPublished,
+}: PublishStatusBannerProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleUnpublish = () => {
+    setError(null);
+    startTransition(() => {
+      unpublishProfile()
+        .then((result) => {
+          if (result.ok) {
+            toast({
+              title: "پروفایل لغو انتشار شد.",
+              description: "پروفایل شما دیگر برای عموم قابل مشاهده نیست.",
+            });
+            router.refresh();
+          } else {
+            setError(result.error ?? "خطایی رخ داد.");
+          }
+        })
+        .catch(() => {
+          setError("خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+        });
+    });
+  };
+
+  return (
+    <div className="space-y-4" dir="rtl">
+      {!canPublish ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-amber-500/60 bg-amber-100/70 p-4 text-sm text-amber-900">
+          <div className="space-y-1">
+            <p className="font-semibold">برای انتشار پروفایل نیاز به اشتراک فعال دارید.</p>
+            <p className="text-xs text-amber-900/80">
+              با ارتقای اشتراک، امکان نمایش عمومی پروفایل برای شما فعال می‌شود.
+            </p>
+          </div>
+          <Button asChild variant="outline" className="border-amber-600 text-amber-800 hover:bg-amber-200">
+            <Link href="/pricing">مشاهده پلن‌های اشتراک</Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="rounded-md border border-emerald-500/50 bg-emerald-100/60 p-4 text-sm text-emerald-900">
+          اشتراک انتشار فعال است. پس از تکمیل اطلاعات می‌توانید پروفایل خود را منتشر کنید.
+        </div>
+      )}
+
+      {isPublished ? (
+        <div className="flex flex-wrap items-center gap-3 rounded-md border border-emerald-500/70 bg-emerald-50 p-4 text-sm text-emerald-900">
+          <div className="flex items-center gap-3">
+            <Badge variant="success" className="px-3 py-1">
+              منتشر شده
+            </Badge>
+            <span>پروفایل شما هم‌اکنون در فهرست عمومی نمایش داده می‌شود.</span>
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={handleUnpublish}
+            disabled={isPending}
+          >
+            لغو انتشار
+          </Button>
+          {error ? <p className="w-full text-sm text-destructive">{error}</p> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/profile/_components/skills-form.tsx
+++ b/apps/web/app/dashboard/profile/_components/skills-form.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import { SKILLS, type SkillKey } from "@/lib/profile/skills";
+
+import { updateSkills } from "../actions";
+
+type SkillsFormProps = {
+  initialSkills: SkillKey[];
+};
+
+type SkillsState = {
+  selections: Set<SkillKey>;
+};
+
+export function SkillsForm({ initialSkills }: SkillsFormProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+  const [state, setState] = useState<SkillsState>({
+    selections: new Set(initialSkills),
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const groupedSkills = useMemo(() => {
+    type SkillItem = (typeof SKILLS)[number];
+    const groups = new Map<string, SkillItem[]>();
+    for (const skill of SKILLS) {
+      if (!groups.has(skill.category)) {
+        groups.set(skill.category, []);
+      }
+      groups.get(skill.category)!.push(skill);
+    }
+    return Array.from(groups.entries());
+  }, []);
+
+  const toggleSkill = (key: SkillKey) => {
+    setState((prev) => {
+      const nextSelections = new Set(prev.selections);
+      if (nextSelections.has(key)) {
+        nextSelections.delete(key);
+      } else {
+        nextSelections.add(key);
+      }
+      return { selections: nextSelections };
+    });
+    setError(null);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const formData = new FormData();
+    for (const key of state.selections) {
+      formData.append("skills", key);
+    }
+
+    startTransition(() => {
+      updateSkills(formData)
+        .then((result) => {
+          if (result.ok) {
+            toast({
+              title: "مهارت‌ها ذخیره شد.",
+              description: "لیست مهارت‌ها با موفقیت به‌روزرسانی شد.",
+            });
+            setError(null);
+            router.refresh();
+          } else {
+            setError(result.error ?? "خطایی رخ داد.");
+          }
+        })
+        .catch(() => {
+          setError("خطایی رخ داد. لطفاً دوباره تلاش کنید.");
+        });
+    });
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      <div className="space-y-4" dir="rtl">
+        {groupedSkills.map(([category, skills]) => (
+          <div key={category} className="space-y-3">
+            <p className="text-sm font-semibold text-muted-foreground">
+              {category === "acting"
+                ? "بازیگری"
+                : category === "voice"
+                  ? "صدا و خوانندگی"
+                  : category === "dance"
+                    ? "رقص"
+                    : category === "music"
+                      ? "موسیقی"
+                      : category === "production"
+                        ? "تولید و پشت صحنه"
+                        : category === "visual"
+                          ? "تصویر"
+                          : category === "post"
+                            ? "پس‌تولید"
+                            : category}
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {skills.map((skill) => {
+                const checked = state.selections.has(skill.key);
+                return (
+                  <label
+                    key={skill.key}
+                    className="flex cursor-pointer items-center justify-between rounded-md border border-border bg-background px-4 py-2 text-sm shadow-sm transition hover:border-primary"
+                  >
+                    <span>{skill.label}</span>
+                    <input
+                      type="checkbox"
+                      name="skills"
+                      value={skill.key}
+                      checked={checked}
+                      onChange={() => toggleSkill(skill.key)}
+                      className="h-4 w-4"
+                      disabled={isPending}
+                    />
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="flex items-center justify-end">
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "در حال ذخیره..." : "ذخیره مهارت‌ها"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/dashboard/profile/actions.ts
+++ b/apps/web/app/dashboard/profile/actions.ts
@@ -1,0 +1,401 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { getServerAuthSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma";
+import { canPublishProfile } from "@/lib/profile/entitlement";
+import { personalInfoSchema, skillsSchema } from "@/lib/profile/validation";
+import { deleteByUrl, saveImageFromFormData } from "@/lib/media/storage";
+
+const GENERIC_ERROR = "خطایی رخ داد. لطفاً دوباره تلاش کنید.";
+const AUTH_ERROR = "نشست شما منقضی شده است. لطفاً دوباره وارد شوید.";
+const NO_PROFILE_ERROR = "ابتدا اطلاعات پروفایل خود را تکمیل کنید.";
+const PUBLISH_ENTITLEMENT_ERROR = "برای انتشار پروفایل نیاز به اشتراک فعال دارید.";
+
+const DASHBOARD_PROFILE_PATHS = [
+  "/dashboard/profile",
+  "/profiles",
+];
+
+type PersonalInfoActionResult = {
+  ok: boolean;
+  fieldErrors?: Partial<Record<keyof z.infer<typeof personalInfoSchema>, string>>;
+  error?: string;
+  data?: { avatarUrl: string };
+};
+
+type SkillsActionResult = {
+  ok: boolean;
+  error?: string;
+};
+
+type GalleryActionResult = {
+  ok: boolean;
+  error?: string;
+  url?: string;
+};
+
+type PublishActionResult = {
+  ok: boolean;
+  error?: string;
+  fieldErrors?: Partial<Record<keyof z.infer<typeof personalInfoSchema>, string>>;
+};
+
+async function ensureSessionUserId(): Promise<string> {
+  const session = await getServerAuthSession();
+
+  if (!session?.user?.id) {
+    throw new Error(AUTH_ERROR);
+  }
+
+  return session.user.id;
+}
+
+async function revalidateProfilePaths(profileId: string) {
+  revalidatePath(`/profiles/${profileId}`);
+  for (const path of DASHBOARD_PROFILE_PATHS) {
+    revalidatePath(path);
+  }
+}
+
+function mapZodErrors(
+  error: z.ZodError<z.infer<typeof personalInfoSchema>>,
+): Partial<Record<keyof z.infer<typeof personalInfoSchema>, string>> {
+  const fieldErrors: Partial<
+    Record<keyof z.infer<typeof personalInfoSchema>, string>
+  > = {};
+
+  for (const issue of error.issues) {
+    const pathKey = issue.path[0];
+    if (typeof pathKey === "string" && !(pathKey in fieldErrors)) {
+      fieldErrors[pathKey as keyof z.infer<typeof personalInfoSchema>] =
+        issue.message;
+    }
+  }
+
+  return fieldErrors;
+}
+
+export async function upsertPersonalInfo(formData: FormData): Promise<PersonalInfoActionResult> {
+  try {
+    const userId = await ensureSessionUserId();
+
+    const rawAvatarUrl = formData.get("avatarUrl");
+    const avatarFile = formData.get("avatar");
+
+    const baseValues = {
+      firstName: (formData.get("firstName") ?? "").toString().trim(),
+      lastName: (formData.get("lastName") ?? "").toString().trim(),
+      stageName: (formData.get("stageName") ?? "").toString().trim(),
+      age: formData.get("age") ?? "",
+      phone: (formData.get("phone") ?? "").toString().trim(),
+      address: (formData.get("address") ?? "").toString().trim(),
+      cityId: (formData.get("cityId") ?? "").toString().trim(),
+      avatarUrl: typeof rawAvatarUrl === "string" ? rawAvatarUrl.trim() : "",
+      bio: (formData.get("bio") ?? "").toString().trim(),
+    } satisfies Record<keyof z.infer<typeof personalInfoSchema>, unknown>;
+
+    let uploadedAvatarUrl: string | null = null;
+
+    if (avatarFile instanceof File && avatarFile.size > 0) {
+      const uploadForm = new FormData();
+      uploadForm.set("file", avatarFile);
+      const { url } = await saveImageFromFormData(uploadForm, userId);
+      baseValues.avatarUrl = url;
+      uploadedAvatarUrl = url;
+    }
+
+    const parsed = personalInfoSchema.safeParse(baseValues);
+
+    if (!parsed.success) {
+      if (uploadedAvatarUrl) {
+        await deleteByUrl(uploadedAvatarUrl, userId);
+      }
+      return {
+        ok: false,
+        fieldErrors: mapZodErrors(parsed.error),
+      };
+    }
+
+    const data = parsed.data;
+
+    const result = await prisma.profile.upsert({
+      where: { userId },
+      create: {
+        userId,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        stageName: data.stageName?.trim() ? data.stageName.trim() : null,
+        age: data.age,
+        phone: data.phone,
+        address: data.address?.trim() ? data.address.trim() : null,
+        cityId: data.cityId,
+        avatarUrl: data.avatarUrl,
+        bio: data.bio?.trim() ? data.bio.trim() : null,
+      },
+      update: {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        stageName: data.stageName?.trim() ? data.stageName.trim() : null,
+        age: data.age,
+        phone: data.phone,
+        address: data.address?.trim() ? data.address.trim() : null,
+        cityId: data.cityId,
+        avatarUrl: data.avatarUrl,
+        bio: data.bio?.trim() ? data.bio.trim() : null,
+      },
+      select: {
+        id: true,
+        avatarUrl: true,
+      },
+    });
+
+    await revalidateProfilePaths(result.id);
+
+    return {
+      ok: true,
+      data: { avatarUrl: result.avatarUrl ?? "" },
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message === AUTH_ERROR) {
+      return { ok: false, error: AUTH_ERROR };
+    }
+
+    console.error("upsertPersonalInfo", error);
+    return { ok: false, error: GENERIC_ERROR };
+  }
+}
+
+export async function updateSkills(formData: FormData): Promise<SkillsActionResult> {
+  try {
+    const userId = await ensureSessionUserId();
+    const rawSkills = formData.getAll("skills").map((value) => value?.toString() ?? "");
+
+    const parsed = skillsSchema.safeParse({ skills: rawSkills });
+
+    if (!parsed.success) {
+      return { ok: false, error: "لیست مهارت‌ها معتبر نیست." };
+    }
+
+    const result = await prisma.profile.upsert({
+      where: { userId },
+      create: {
+        userId,
+        skills: parsed.data.skills,
+      },
+      update: {
+        skills: parsed.data.skills,
+      },
+      select: { id: true },
+    });
+
+    await revalidateProfilePaths(result.id);
+
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof Error && error.message === AUTH_ERROR) {
+      return { ok: false, error: AUTH_ERROR };
+    }
+
+    console.error("updateSkills", error);
+    return { ok: false, error: GENERIC_ERROR };
+  }
+}
+
+export async function uploadImage(formData: FormData): Promise<GalleryActionResult> {
+  try {
+    const userId = await ensureSessionUserId();
+    const file = formData.get("file");
+
+    if (!(file instanceof File) || file.size === 0) {
+      return { ok: false, error: "لطفاً یک تصویر انتخاب کنید." };
+    }
+
+    const uploadForm = new FormData();
+    uploadForm.set("file", file);
+    const { url } = await saveImageFromFormData(uploadForm, userId);
+
+    const profile = await prisma.profile.findUnique({
+      where: { userId },
+      select: { id: true, gallery: true },
+    });
+
+    const currentGallery = Array.isArray(profile?.gallery)
+      ? (profile?.gallery as Array<{ url: string }>)
+      : [];
+
+    const nextGallery = [...currentGallery, { url }];
+
+    const result = await prisma.profile.upsert({
+      where: { userId },
+      create: {
+        userId,
+        gallery: nextGallery,
+      },
+      update: {
+        gallery: nextGallery,
+      },
+      select: { id: true },
+    });
+
+    await revalidateProfilePaths(result.id);
+
+    return { ok: true, url };
+  } catch (error) {
+    if (error instanceof Error && error.message === AUTH_ERROR) {
+      return { ok: false, error: AUTH_ERROR };
+    }
+
+    console.error("uploadImage", error);
+    return { ok: false, error: GENERIC_ERROR };
+  }
+}
+
+export async function deleteImage(formData: FormData): Promise<GalleryActionResult> {
+  try {
+    const userId = await ensureSessionUserId();
+    const url = (formData.get("url") ?? "").toString();
+
+    if (!url) {
+      return { ok: false, error: "آدرس تصویر نامعتبر است." };
+    }
+
+    const profile = await prisma.profile.findUnique({
+      where: { userId },
+      select: { id: true, gallery: true },
+    });
+
+    if (!profile) {
+      return { ok: false, error: NO_PROFILE_ERROR };
+    }
+
+    const currentGallery = Array.isArray(profile.gallery)
+      ? (profile.gallery as Array<{ url: string }>)
+      : [];
+
+    const nextGallery = currentGallery.filter((item) => item.url !== url);
+
+    await prisma.profile.update({
+      where: { userId },
+      data: { gallery: nextGallery },
+    });
+
+    await deleteByUrl(url, userId);
+    await revalidateProfilePaths(profile.id);
+
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof Error && error.message === AUTH_ERROR) {
+      return { ok: false, error: AUTH_ERROR };
+    }
+
+    console.error("deleteImage", error);
+    return { ok: false, error: GENERIC_ERROR };
+  }
+}
+
+export async function publishProfile(): Promise<PublishActionResult> {
+  try {
+    const userId = await ensureSessionUserId();
+    const profile = await prisma.profile.findUnique({
+      where: { userId },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        stageName: true,
+        age: true,
+        phone: true,
+        address: true,
+        cityId: true,
+        avatarUrl: true,
+        bio: true,
+      },
+    });
+
+    if (!profile) {
+      return { ok: false, error: NO_PROFILE_ERROR };
+    }
+
+    const entitlement = await canPublishProfile(userId);
+
+    if (!entitlement) {
+      return { ok: false, error: PUBLISH_ENTITLEMENT_ERROR };
+    }
+
+    const validationPayload = {
+      firstName: profile.firstName ?? "",
+      lastName: profile.lastName ?? "",
+      stageName: profile.stageName ?? "",
+      age: profile.age ?? "",
+      phone: profile.phone ?? "",
+      address: profile.address ?? "",
+      cityId: profile.cityId ?? "",
+      avatarUrl: profile.avatarUrl ?? "",
+      bio: profile.bio ?? "",
+    };
+
+    const parsed = personalInfoSchema.safeParse(validationPayload);
+
+    if (!parsed.success) {
+      return {
+        ok: false,
+        fieldErrors: mapZodErrors(parsed.error),
+      };
+    }
+
+    await prisma.profile.update({
+      where: { userId },
+      data: {
+        visibility: "PUBLIC",
+        publishedAt: new Date(),
+      },
+    });
+
+    await revalidateProfilePaths(profile.id);
+
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof Error && error.message === AUTH_ERROR) {
+      return { ok: false, error: AUTH_ERROR };
+    }
+
+    console.error("publishProfile", error);
+    return { ok: false, error: GENERIC_ERROR };
+  }
+}
+
+export async function unpublishProfile(): Promise<PublishActionResult> {
+  try {
+    const userId = await ensureSessionUserId();
+    const profile = await prisma.profile.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
+
+    if (!profile) {
+      return { ok: false, error: NO_PROFILE_ERROR };
+    }
+
+    await prisma.profile.update({
+      where: { userId },
+      data: {
+        visibility: "PRIVATE",
+        publishedAt: null,
+      },
+    });
+
+    await revalidateProfilePaths(profile.id);
+
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof Error && error.message === AUTH_ERROR) {
+      return { ok: false, error: AUTH_ERROR };
+    }
+
+    console.error("unpublishProfile", error);
+    return { ok: false, error: GENERIC_ERROR };
+  }
+}

--- a/apps/web/app/dashboard/profile/page.tsx
+++ b/apps/web/app/dashboard/profile/page.tsx
@@ -1,34 +1,179 @@
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { redirect } from "next/navigation";
 
-export default function ProfilePage() {
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getServerAuthSession } from "@/lib/auth/session";
+import { getCities } from "@/lib/location/cities";
+import { prisma } from "@/lib/prisma";
+import { canPublishProfile } from "@/lib/profile/entitlement";
+import { SKILLS, type SkillKey } from "@/lib/profile/skills";
+import { validateReadyToPublish } from "@/lib/profile/validation";
+
+import { MediaGallery } from "./_components/media-gallery";
+import { PersonalInfoForm } from "./_components/personal-info-form";
+import { PublishPanel } from "./_components/publish-panel";
+import { PublishStatusBanner } from "./_components/publish-status-banner";
+import { SkillsForm } from "./_components/skills-form";
+
+type GalleryEntry = {
+  url?: unknown;
+  width?: unknown;
+  height?: unknown;
+};
+
+type PrismaProfile = NonNullable<Awaited<ReturnType<typeof prisma.profile.findUnique>>>;
+
+function normalizeGallery(
+  gallery: PrismaProfile["gallery"] | null | undefined,
+): { url: string }[] {
+  if (!Array.isArray(gallery)) {
+    return [];
+  }
+
+  const images: { url: string }[] = [];
+
+  for (const item of gallery as GalleryEntry[]) {
+    if (item && typeof item === "object" && typeof item.url === "string") {
+      images.push({ url: item.url });
+    }
+  }
+
+  return images;
+}
+
+function normalizeSkills(
+  skills: PrismaProfile["skills"] | null | undefined,
+): SkillKey[] {
+  if (!Array.isArray(skills)) {
+    return [];
+  }
+
+  const allowed = new Set(SKILLS.map((skill) => skill.key));
+  const result: SkillKey[] = [];
+
+  for (const entry of skills) {
+    if (typeof entry === "string" && allowed.has(entry as SkillKey)) {
+      result.push(entry as SkillKey);
+    }
+  }
+
+  return result;
+}
+
+export default async function DashboardProfilePage() {
+  const session = await getServerAuthSession();
+
+  if (!session?.user?.id) {
+    redirect("/auth/signin");
+  }
+
+  const userId = session.user.id;
+
+  const [profile, cities, entitlementActive] = await Promise.all([
+    prisma.profile.findUnique({
+      where: { userId },
+    }),
+    getCities(),
+    canPublishProfile(userId),
+  ]);
+
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+
+  const galleryImages = normalizeGallery(profile?.gallery ?? null);
+  const selectedSkills = normalizeSkills(profile?.skills ?? null);
+  const cityName = profile?.cityId ? cityMap.get(profile.cityId) ?? undefined : undefined;
+
+  const readinessResult = profile
+    ? validateReadyToPublish({
+        firstName: profile.firstName ?? "",
+        lastName: profile.lastName ?? "",
+        stageName: profile.stageName ?? "",
+        age: profile.age ?? "",
+        phone: profile.phone ?? "",
+        address: profile.address ?? "",
+        cityId: profile.cityId ?? "",
+        avatarUrl: profile.avatarUrl ?? "",
+        bio: profile.bio ?? "",
+      })
+    : null;
+
+  const readinessIssues = readinessResult
+    ? readinessResult.success
+      ? []
+      : readinessResult.error.issues.map((issue) => issue.message)
+    : ["لطفاً اطلاعات فردی خود را تکمیل کنید."];
+
+  const isPublished = profile?.visibility === "PUBLIC";
+
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
+    <div className="mx-auto flex max-w-5xl flex-col gap-6" dir="rtl">
+      <PublishStatusBanner canPublish={entitlementActive} isPublished={isPublished ?? false} />
+
       <Card>
         <CardHeader>
-          <CardTitle>پروفایل کاربری</CardTitle>
+          <CardTitle>اطلاعات فردی</CardTitle>
           <CardDescription>
-            ویرایش پروفایل در فاز بعدی اضافه می‌شود. در حال حاضر می‌توانید سایر بخش‌های پنل را بررسی کنید.
+            برای انتشار پروفایل، تکمیل همه فیلدهای این بخش الزامی است.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-wrap gap-3">
-            <Button variant="secondary" disabled>
-              تکمیل اطلاعات پایه
-            </Button>
-            <Button variant="outline" disabled>
-              افزودن نمونه‌کار
-            </Button>
-            <Button variant="ghost" disabled>
-              مدیریت شبکه‌های اجتماعی
-            </Button>
-          </div>
+          <PersonalInfoForm
+            cities={cities}
+            initialValues={{
+              firstName: profile?.firstName ?? "",
+              lastName: profile?.lastName ?? "",
+              stageName: profile?.stageName ?? "",
+              age: profile?.age ?? null,
+              phone: profile?.phone ?? "",
+              address: profile?.address ?? "",
+              cityId: profile?.cityId ?? "",
+              avatarUrl: profile?.avatarUrl ?? "",
+              bio: profile?.bio ?? "",
+            }}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>مهارت‌ها</CardTitle>
+          <CardDescription>انتخاب مهارت‌ها اختیاری است اما به کشف بهتر شما کمک می‌کند.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <SkillsForm initialSkills={selectedSkills} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>رسانه‌ها</CardTitle>
+          <CardDescription>تصاویر مرتبط با فعالیت‌های هنری خود را در این بخش بارگذاری کنید.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <MediaGallery images={galleryImages} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>پیش‌نمایش و انتشار</CardTitle>
+          <CardDescription>پیش از انتشار وضعیت پروفایل خود را بررسی کنید.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <PublishPanel
+            canPublish={entitlementActive}
+            isPublished={isPublished ?? false}
+            readinessIssues={readinessIssues}
+            personalInfo={{
+              firstName: profile?.firstName ?? "",
+              lastName: profile?.lastName ?? "",
+              stageName: profile?.stageName ?? "",
+              age: profile?.age ?? null,
+              phone: profile?.phone ?? "",
+              address: profile?.address ?? "",
+              cityName,
+              bio: profile?.bio ?? "",
+            }}
+          />
         </CardContent>
       </Card>
     </div>

--- a/apps/web/app/profiles/[id]/page.tsx
+++ b/apps/web/app/profiles/[id]/page.tsx
@@ -1,0 +1,225 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { getCities } from "@/lib/location/cities";
+import { prisma } from "@/lib/prisma";
+import { SKILLS, type SkillKey } from "@/lib/profile/skills";
+
+import type { Metadata } from "next";
+
+type GalleryEntry = {
+  url?: unknown;
+  width?: unknown;
+  height?: unknown;
+};
+
+type SocialLinks = Record<string, unknown> | null | undefined;
+
+type Props = {
+  params: {
+    id: string;
+  };
+};
+
+const SKILL_LABELS = new Map(SKILLS.map((skill) => [skill.key, skill.label] as const));
+
+function normalizeGallery(gallery: unknown): { url: string }[] {
+  if (!Array.isArray(gallery)) {
+    return [];
+  }
+
+  const images: { url: string }[] = [];
+  for (const entry of gallery as GalleryEntry[]) {
+    if (entry && typeof entry === "object" && typeof entry.url === "string") {
+      images.push({ url: entry.url });
+    }
+  }
+  return images;
+}
+
+function normalizeSkills(skills: unknown): string[] {
+  if (!Array.isArray(skills)) {
+    return [];
+  }
+
+  const labels: string[] = [];
+  for (const entry of skills) {
+    if (typeof entry === "string" && SKILL_LABELS.has(entry as SkillKey)) {
+      labels.push(SKILL_LABELS.get(entry as SkillKey) ?? entry);
+    }
+  }
+  return labels;
+}
+
+function extractSocialLinks(raw: SocialLinks): string[] {
+  if (!raw || typeof raw !== "object") {
+    return [];
+  }
+
+  const links: string[] = [];
+  for (const value of Object.values(raw)) {
+    if (typeof value === "string" && value.trim().startsWith("http")) {
+      links.push(value.trim());
+    }
+  }
+  return links;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const profile = await prisma.profile.findUnique({
+    where: { id: params.id },
+    select: {
+      visibility: true,
+      stageName: true,
+      firstName: true,
+      lastName: true,
+      bio: true,
+      avatarUrl: true,
+    },
+  });
+
+  if (!profile || profile.visibility !== "PUBLIC") {
+    return {};
+  }
+
+  const title = profile.stageName?.trim()
+    ? profile.stageName
+    : `${profile.firstName ?? ""} ${profile.lastName ?? ""}`.trim();
+
+  return {
+    title: title || "پروفایل هنرمند",
+    description: profile.bio ?? undefined,
+    openGraph: {
+      title: title || undefined,
+      description: profile.bio ?? undefined,
+      images: profile.avatarUrl ? [profile.avatarUrl] : undefined,
+    },
+  };
+}
+
+export default async function PublicProfilePage({ params }: Props) {
+  const profile = await prisma.profile.findUnique({
+    where: { id: params.id },
+  });
+
+  if (!profile || profile.visibility !== "PUBLIC") {
+    notFound();
+  }
+
+  const [cities, socialLinks] = await Promise.all([
+    getCities(),
+    Promise.resolve(extractSocialLinks(profile.socialLinks as SocialLinks)),
+  ]);
+
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+  const gallery = normalizeGallery(profile.gallery);
+  const skills = normalizeSkills(profile.skills);
+  const cityName = profile.cityId ? cityMap.get(profile.cityId) ?? profile.cityId : undefined;
+
+  const displayName = profile.stageName?.trim()
+    ? profile.stageName.trim()
+    : `${profile.firstName ?? ""} ${profile.lastName ?? ""}`.trim() || "پروفایل";
+
+  const jsonLd: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: displayName,
+    ...(profile.stageName ? { alternateName: profile.stageName } : {}),
+    ...(profile.avatarUrl ? { image: profile.avatarUrl } : {}),
+    ...(cityName
+      ? {
+          homeLocation: {
+            "@type": "Place",
+            name: cityName,
+          },
+        }
+      : {}),
+    ...(socialLinks.length
+      ? {
+          sameAs: socialLinks,
+        }
+      : {}),
+  };
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 pb-12" dir="rtl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <header className="flex flex-col items-start gap-6 rounded-md border border-border bg-background p-6 shadow-sm">
+        <div className="flex w-full flex-col gap-6 sm:flex-row sm:items-center">
+          {profile.avatarUrl ? (
+            <div className="h-40 w-40 overflow-hidden rounded-lg border border-border/60">
+              <Image
+                src={profile.avatarUrl}
+                alt={`تصویر ${displayName}`}
+                width={256}
+                height={256}
+                className="h-full w-full object-cover"
+              />
+            </div>
+          ) : null}
+          <div className="flex-1 space-y-3">
+            <h1 className="text-3xl font-bold">{displayName}</h1>
+            {cityName ? (
+              <p className="text-sm text-muted-foreground">ساکن {cityName}</p>
+            ) : null}
+            {profile.bio ? (
+              <p className="text-sm leading-7 text-muted-foreground">{profile.bio}</p>
+            ) : null}
+          </div>
+        </div>
+        {skills.length ? (
+          <div className="flex flex-wrap gap-2">
+            {skills.map((skill) => (
+              <span
+                key={skill}
+                className="rounded-full border border-border bg-muted px-3 py-1 text-xs text-muted-foreground"
+              >
+                {skill}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {socialLinks.length ? (
+          <div className="flex flex-wrap gap-3 text-sm">
+            {socialLinks.map((link) => (
+              <a
+                key={link}
+                href={link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                {link}
+              </a>
+            ))}
+          </div>
+        ) : null}
+      </header>
+
+      {gallery.length ? (
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">گالری تصاویر</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {gallery.map((item) => (
+              <Card key={item.url}>
+                <CardContent className="p-0">
+                  <Image
+                    src={item.url}
+                    alt={`تصویر ${displayName}`}
+                    width={600}
+                    height={400}
+                    className="h-64 w-full rounded-md object-cover"
+                  />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/profiles/page.tsx
+++ b/apps/web/app/profiles/page.tsx
@@ -1,0 +1,207 @@
+import Link from "next/link";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { getCities } from "@/lib/location/cities";
+import { prisma } from "@/lib/prisma";
+import { SKILLS, type SkillKey } from "@/lib/profile/skills";
+
+const SKILL_OPTIONS = SKILLS.map((skill) => ({ key: skill.key, label: skill.label }));
+
+type SearchParams = {
+  city?: string | string[];
+  skill?: string | string[];
+};
+
+type DirectoryProfile = {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  stageName: string | null;
+  avatarUrl: string | null;
+  cityId: string | null;
+  updatedAt: Date;
+  skills: unknown;
+};
+
+function normalizeSkillLabels(skills: unknown): string[] {
+  if (!Array.isArray(skills)) {
+    return [];
+  }
+  const labels: string[] = [];
+  const labelMap = new Map(SKILLS.map((skill) => [skill.key, skill.label] as const));
+  for (const entry of skills) {
+    if (typeof entry === "string" && labelMap.has(entry as SkillKey)) {
+      labels.push(labelMap.get(entry as SkillKey) ?? entry);
+    }
+  }
+  return labels;
+}
+
+function getDisplayName(profile: DirectoryProfile) {
+  if (profile.stageName?.trim()) {
+    return profile.stageName.trim();
+  }
+  const fullName = `${profile.firstName ?? ""} ${profile.lastName ?? ""}`.trim();
+  return fullName || "بدون نام";
+}
+
+export default async function ProfilesDirectory({ searchParams }: { searchParams: SearchParams }) {
+  const cityFilter = typeof searchParams.city === "string" ? searchParams.city : undefined;
+  const skillFilter = typeof searchParams.skill === "string" ? searchParams.skill : undefined;
+
+  const [cities, profiles] = await Promise.all([
+    getCities(),
+    prisma.profile.findMany({
+      where: {
+        visibility: "PUBLIC",
+        ...(cityFilter ? { cityId: cityFilter } : {}),
+        ...(skillFilter
+          ? {
+              skills: {
+                array_contains: [skillFilter],
+              },
+            }
+          : {}),
+      },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        stageName: true,
+        avatarUrl: true,
+        cityId: true,
+        updatedAt: true,
+        skills: true,
+      },
+    }),
+  ]);
+
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-6 pb-12" dir="rtl">
+      <Card>
+        <CardHeader>
+          <CardTitle>پروفایل هنرمندان</CardTitle>
+          <CardDescription>با فیلتر کردن بر اساس شهر و مهارت، هنرمند مورد نظر خود را پیدا کنید.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-4 sm:grid-cols-2" method="get">
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium" htmlFor="city">
+                شهر
+              </label>
+              <select
+                id="city"
+                name="city"
+                defaultValue={cityFilter ?? ""}
+                className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+              >
+                <option value="">همه شهرها</option>
+                {cities.map((city) => (
+                  <option key={city.id} value={city.id}>
+                    {city.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium" htmlFor="skill">
+                مهارت
+              </label>
+              <select
+                id="skill"
+                name="skill"
+                defaultValue={skillFilter ?? ""}
+                className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+              >
+                <option value="">همه مهارت‌ها</option>
+                {SKILL_OPTIONS.map((skill) => (
+                  <option key={skill.key} value={skill.key}>
+                    {skill.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="sm:col-span-2">
+              <button
+                type="submit"
+                className="w-full rounded-md bg-primary py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+              >
+                اعمال فیلتر
+              </button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {profiles.length === 0 ? (
+        <div className="rounded-md border border-border bg-background p-6 text-center text-sm text-muted-foreground">
+          هنرمندی با فیلترهای انتخابی یافت نشد.
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {profiles.map((profile) => {
+            const displayName = getDisplayName(profile);
+            const skills = normalizeSkillLabels(profile.skills);
+            const updatedLabel = new Intl.DateTimeFormat("fa-IR", {
+              dateStyle: "medium",
+            }).format(profile.updatedAt);
+            const cityName = profile.cityId ? cityMap.get(profile.cityId) ?? profile.cityId : undefined;
+
+            return (
+              <Link
+                key={profile.id}
+                href={`/profiles/${profile.id}`}
+                className="group rounded-md border border-border bg-background shadow-sm transition hover:border-primary"
+              >
+                <Card className="border-none">
+                  <CardHeader className="flex flex-row items-center gap-4">
+                    {profile.avatarUrl ? (
+                      <div className="h-16 w-16 overflow-hidden rounded-full border border-border/60">
+                        <img
+                          src={profile.avatarUrl}
+                          alt={displayName}
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
+                    ) : null}
+                    <div className="space-y-1">
+                      <CardTitle className="text-lg font-semibold text-foreground">
+                        {displayName}
+                      </CardTitle>
+                      {cityName ? (
+                        <CardDescription>شهر: {cityName}</CardDescription>
+                      ) : null}
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {skills.length ? (
+                      <div className="flex flex-wrap gap-2">
+                        {skills.slice(0, 4).map((skill) => (
+                          <Badge key={skill} variant="outline" className="bg-muted">
+                            {skill}
+                          </Badge>
+                        ))}
+                        {skills.length > 4 ? (
+                          <span className="text-xs text-muted-foreground">
+                            +{skills.length - 4} مورد دیگر
+                          </span>
+                        ) : null}
+                      </div>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">مهارتی ثبت نشده است.</p>
+                    )}
+                    <p className="text-xs text-muted-foreground">به‌روزرسانی: {updatedLabel}</p>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/location/cities.ts
+++ b/apps/web/lib/location/cities.ts
@@ -1,0 +1,6 @@
+export type City = { id: string; name: string };
+
+export async function getCities(): Promise<City[]> {
+  // TODO: replace with real list when provided
+  return [];
+}

--- a/apps/web/lib/media/storage.ts
+++ b/apps/web/lib/media/storage.ts
@@ -1,0 +1,78 @@
+import crypto from "node:crypto";
+import { existsSync } from "node:fs";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const ALLOWED_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+]);
+
+function getExtension(mimeType: string): string {
+  switch (mimeType) {
+    case "image/png":
+      return ".png";
+    case "image/jpeg":
+      return ".jpg";
+    case "image/webp":
+      return ".webp";
+    default:
+      throw new Error("نوع فایل پشتیبانی نمی‌شود.");
+  }
+}
+
+const PUBLIC_DIR = (() => {
+  const cwd = process.cwd();
+  const direct = path.join(cwd, "public");
+  if (existsSync(direct)) {
+    return direct;
+  }
+  return path.join(cwd, "apps", "web", "public");
+})();
+
+export async function saveImageFromFormData(
+  formData: FormData,
+  userId: string,
+): Promise<{ url: string }> {
+  const file = formData.get("file");
+
+  if (!(file instanceof File)) {
+    throw new Error("فایل تصویر یافت نشد.");
+  }
+
+  if (!ALLOWED_MIME_TYPES.has(file.type)) {
+    throw new Error("لطفاً تصویری با فرمت مجاز (PNG، JPEG یا WEBP) بارگذاری کنید.");
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const extension = getExtension(file.type);
+
+  const uploadsDir = path.join(PUBLIC_DIR, "uploads", userId);
+  await fs.mkdir(uploadsDir, { recursive: true });
+
+  const fileName = `${Date.now()}-${crypto.randomUUID()}${extension}`;
+  const filePath = path.join(uploadsDir, fileName);
+
+  await fs.writeFile(filePath, buffer);
+
+  const url = path.posix.join("/uploads", userId, fileName);
+  return { url };
+}
+
+export async function deleteByUrl(url: string, userId: string): Promise<void> {
+  if (!url.startsWith("/uploads/")) {
+    throw new Error("آدرس فایل نامعتبر است.");
+  }
+
+  const normalized = url.replace(/^\/+/, "");
+  const segments = normalized.split("/");
+
+  if (segments.length < 3 || segments[0] !== "uploads" || segments[1] !== userId) {
+    throw new Error("دسترسی به حذف این فایل مجاز نیست.");
+  }
+
+  const filePath = path.join(PUBLIC_DIR, normalized);
+  await fs.rm(filePath, { force: true });
+}

--- a/apps/web/lib/profile/entitlement.ts
+++ b/apps/web/lib/profile/entitlement.ts
@@ -1,0 +1,26 @@
+import { CAN_PUBLISH_PROFILE } from "@/lib/billing/entitlementKeys";
+import { prisma } from "@/lib/prisma";
+
+export async function canPublishProfile(userId: string): Promise<boolean> {
+  const entitlement = await prisma.userEntitlement.findUnique({
+    where: {
+      userId_key: {
+        userId,
+        key: CAN_PUBLISH_PROFILE,
+      },
+    },
+    select: {
+      expiresAt: true,
+    },
+  });
+
+  if (!entitlement) {
+    return false;
+  }
+
+  if (!entitlement.expiresAt) {
+    return true;
+  }
+
+  return entitlement.expiresAt > new Date();
+}

--- a/apps/web/lib/profile/skills.ts
+++ b/apps/web/lib/profile/skills.ts
@@ -1,0 +1,34 @@
+export type SkillKey =
+  | "acting_camera"
+  | "acting_stage"
+  | "voice_over"
+  | "singing_pop"
+  | "singing_traditional"
+  | "dance_modern"
+  | "dance_traditional"
+  | "music_instrument_setar"
+  | "music_instrument_guitar"
+  | "directing_shortfilm"
+  | "screenwriting"
+  | "makeup_cinematic"
+  | "photography_portrait"
+  | "editing_video";
+
+export const SKILLS: { key: SkillKey; label: string; category: string }[] = [
+  { key: "acting_camera", label: "بازیگری جلوی دوربین", category: "acting" },
+  { key: "acting_stage", label: "بازیگری تئاتر", category: "acting" },
+  { key: "voice_over", label: "دوبله و صداپیشگی", category: "voice" },
+  { key: "singing_pop", label: "خوانندگی پاپ", category: "voice" },
+  { key: "singing_traditional", label: "خوانندگی سنتی", category: "voice" },
+  { key: "dance_modern", label: "رقص مدرن", category: "dance" },
+  { key: "dance_traditional", label: "رقص سنتی ایرانی", category: "dance" },
+  { key: "music_instrument_setar", label: "نوازندگی سه‌تار", category: "music" },
+  { key: "music_instrument_guitar", label: "نوازندگی گیتار", category: "music" },
+  { key: "directing_shortfilm", label: "کارگردانی فیلم کوتاه", category: "production" },
+  { key: "screenwriting", label: "فیلمنامه‌نویسی", category: "production" },
+  { key: "makeup_cinematic", label: "گریم سینمایی", category: "production" },
+  { key: "photography_portrait", label: "عکاسی پرتره", category: "visual" },
+  { key: "editing_video", label: "تدوین ویدیو", category: "post" },
+];
+
+export const SKILL_KEYS = SKILLS.map((skill) => skill.key) as SkillKey[];

--- a/apps/web/lib/profile/validation.ts
+++ b/apps/web/lib/profile/validation.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+import { SKILL_KEYS } from "./skills";
+
+export const personalInfoSchema = z.object({
+  firstName: z.string().trim().min(1, "لطفاً نام را وارد کنید.").max(191),
+  lastName: z.string().trim().min(1, "لطفاً نام خانوادگی را وارد کنید.").max(191),
+  stageName: z.string().trim().max(191).optional().or(z.literal("")),
+  age: z.coerce.number().int().min(5, "سن معتبر نیست.").max(120, "سن معتبر نیست."),
+  phone: z
+    .string()
+    .regex(/^0\d{9}$/, "شماره تلفن باید با 0 شروع شده و 10 رقم باشد."),
+  address: z.string().trim().max(1000).optional().or(z.literal("")),
+  cityId: z
+    .string()
+    .trim()
+    .min(1, "لطفاً شهر را انتخاب کنید."),
+  avatarUrl: z
+    .string()
+    .trim()
+    .url("لطفاً تصویر پروفایل معتبر انتخاب کنید."),
+  bio: z.string().trim().max(2000).optional().or(z.literal("")),
+});
+
+export const skillsSchema = z.object({
+  skills: z
+    .array(z.enum(SKILL_KEYS as unknown as [any, ...any[]]))
+    .optional()
+    .default([]),
+});
+
+export function validateReadyToPublish(input: unknown) {
+  return personalInfoSchema.safeParse(input);
+}

--- a/apps/web/prisma/migrations/20251005004814_sprint3_profile_entity/migration.sql
+++ b/apps/web/prisma/migrations/20251005004814_sprint3_profile_entity/migration.sql
@@ -1,0 +1,31 @@
+-- CreateEnum
+CREATE TYPE "ProfileVisibility" AS ENUM ('PUBLIC', 'PRIVATE');
+
+-- CreateTable
+CREATE TABLE "Profile" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "firstName" TEXT,
+    "lastName" TEXT,
+    "stageName" TEXT,
+    "age" INTEGER,
+    "phone" TEXT,
+    "address" TEXT,
+    "cityId" TEXT,
+    "avatarUrl" TEXT,
+    "bio" TEXT,
+    "gallery" JSONB,
+    "skills" JSONB,
+    "socialLinks" JSONB,
+    "visibility" "ProfileVisibility" NOT NULL DEFAULT 'PRIVATE',
+    "publishedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_userId_key" ON "Profile"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -18,6 +18,33 @@ model User {
   invoices         Invoice[]
   payments         Payment[]
   entitlements     UserEntitlement[]
+  profile          Profile?
+}
+
+model Profile {
+  id          String             @id @default(cuid())
+  userId      String             @unique
+  user        User               @relation(fields: [userId], references: [id])
+
+  firstName   String?
+  lastName    String?
+  stageName   String?
+  age         Int?
+  phone       String?
+  address     String?
+  cityId      String?
+
+  avatarUrl   String?
+  bio         String?
+  gallery     Json?
+
+  skills      Json?
+  socialLinks Json?
+
+  visibility  ProfileVisibility  @default(PRIVATE)
+  publishedAt DateTime?
+  createdAt   DateTime           @default(now())
+  updatedAt   DateTime           @updatedAt
 }
 
 model Product {
@@ -156,6 +183,11 @@ enum PaymentStatus {
   PENDING
   PAID
   FAILED
+}
+
+enum ProfileVisibility {
+  PUBLIC
+  PRIVATE
 }
 
 enum Role {


### PR DESCRIPTION
## Summary
- add the Prisma profile entity with migrations and shared validation helpers
- implement the dashboard profile editor with skills, media uploads, and publish controls gated by entitlements
- surface published profiles on new public profile detail and directory pages without exposing private fields

## Testing
- pnpm --filter @app/web lint *(fails: registry access blocked in environment)*
- pnpm --filter @app/web prisma generate *(fails: registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1bf8c4dc08327948da6e470c1fc4f