### PR TITLE
Fix profile validation and raise server action body limit

### DIFF
--- a/apps/web/app/dashboard/profile/actions.ts
+++ b/apps/web/app/dashboard/profile/actions.ts
@@ -19,6 +19,33 @@ const DASHBOARD_PROFILE_PATHS = [
   "/profiles",
 ];
 
+const DIGIT_MAP: Record<string, string> = {
+  "۰": "0",
+  "۱": "1",
+  "۲": "2",
+  "۳": "3",
+  "۴": "4",
+  "۵": "5",
+  "۶": "6",
+  "۷": "7",
+  "۸": "8",
+  "۹": "9",
+  "٠": "0",
+  "١": "1",
+  "٢": "2",
+  "٣": "3",
+  "٤": "4",
+  "٥": "5",
+  "٦": "6",
+  "٧": "7",
+  "٨": "8",
+  "٩": "9",
+};
+
+function normalizeDigits(value: string): string {
+  return value.replace(/[۰-۹٠-٩]/g, (char) => DIGIT_MAP[char] ?? char);
+}
+
 type PersonalInfoActionResult = {
   ok: boolean;
   fieldErrors?: Partial<Record<keyof z.infer<typeof personalInfoSchema>, string>>;
@@ -90,7 +117,7 @@ export async function upsertPersonalInfo(formData: FormData): Promise<PersonalIn
       lastName: (formData.get("lastName") ?? "").toString().trim(),
       stageName: (formData.get("stageName") ?? "").toString().trim(),
       age: formData.get("age") ?? "",
-      phone: (formData.get("phone") ?? "").toString().trim(),
+      phone: normalizeDigits((formData.get("phone") ?? "").toString().trim()),
       address: (formData.get("address") ?? "").toString().trim(),
       cityId: (formData.get("cityId") ?? "").toString().trim(),
       avatarUrl: typeof rawAvatarUrl === "string" ? rawAvatarUrl.trim() : "",
@@ -330,7 +357,7 @@ export async function publishProfile(): Promise<PublishActionResult> {
       lastName: profile.lastName ?? "",
       stageName: profile.stageName ?? "",
       age: profile.age ?? "",
-      phone: profile.phone ?? "",
+      phone: normalizeDigits(profile.phone ?? ""),
       address: profile.address ?? "",
       cityId: profile.cityId ?? "",
       avatarUrl: profile.avatarUrl ?? "",

--- a/apps/web/lib/profile/validation.ts
+++ b/apps/web/lib/profile/validation.ts
@@ -2,6 +2,27 @@ import { z } from "zod";
 
 import { SKILL_KEYS } from "./skills";
 
+const AVATAR_URL_ERROR = "لطفاً تصویر پروفایل معتبر انتخاب کنید.";
+
+const AVATAR_UPLOAD_REGEX = /^\/uploads\/[A-Za-z0-9/_.-]+$/;
+
+function isValidAvatarUrl(value: string): boolean {
+  if (value === "") {
+    return true;
+  }
+
+  if (AVATAR_UPLOAD_REGEX.test(value)) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch (error) {
+    return false;
+  }
+}
+
 export const personalInfoSchema = z.object({
   firstName: z.string().trim().min(1, "لطفاً نام را وارد کنید.").max(191),
   lastName: z.string().trim().min(1, "لطفاً نام خانوادگی را وارد کنید.").max(191),
@@ -9,6 +30,7 @@ export const personalInfoSchema = z.object({
   age: z.coerce.number().int().min(5, "سن معتبر نیست.").max(120, "سن معتبر نیست."),
   phone: z
     .string()
+    .trim()
     .regex(/^0\d{10}$/, "شماره تلفن باید با 0 شروع شده و 11 رقم باشد."),
   address: z.string().trim().max(1000).optional().or(z.literal("")),
   cityId: z
@@ -18,7 +40,7 @@ export const personalInfoSchema = z.object({
   avatarUrl: z
     .string()
     .trim()
-    .url("لطفاً تصویر پروفایل معتبر انتخاب کنید."),
+    .refine(isValidAvatarUrl, AVATAR_URL_ERROR),
   bio: z.string().trim().max(2000).optional().or(z.literal("")),
 });
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,10 +1,11 @@
 const config = {
-
   reactStrictMode: true,
   experimental: {
-    typedRoutes: true
-  }
+    typedRoutes: true,
+    serverActions: {
+      bodySizeLimit: "5mb",
+    },
+  },
 } satisfies import("next").NextConfig;
-
 
 export default config;


### PR DESCRIPTION
## Summary
- allow relative upload URLs for profile avatars and trim phone numbers before validation
- normalize Persian and Arabic numerals prior to validating phone numbers on profile forms
- raise the server action body size limit to 5 MB to accommodate larger avatar uploads

## Testing
- pnpm --filter @app/web lint *(fails: registry download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f574eb9083278a17417638fb61a3