### PR TITLE
feat: add admin moderation panel

### DIFF
--- a/apps/web/app/admin/moderation/[id]/page.tsx
+++ b/apps/web/app/admin/moderation/[id]/page.tsx
@@ -1,0 +1,328 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getCities } from "@/lib/location/cities";
+import { getModerationDetail } from "@/lib/profile/moderation";
+import { SKILLS } from "@/lib/profile/skills";
+
+import { ModerationActions } from "../_components/moderation-actions";
+
+type GalleryEntry = {
+  url?: unknown;
+  width?: unknown;
+  height?: unknown;
+};
+
+type SocialLinks = Record<string, unknown> | null | undefined;
+
+type EventLabelMap = Record<
+  "APPROVE" | "REJECT" | "REVERT_TO_PENDING" | "HIDE" | "UNHIDE" | "SYSTEM_AUTO_UNPUBLISH",
+  string
+>;
+
+const STATUS_LABELS = {
+  PENDING: "در انتظار بررسی",
+  APPROVED: "تایید شده",
+  REJECTED: "رد شده",
+} as const;
+
+const STATUS_VARIANTS = {
+  PENDING: "warning",
+  APPROVED: "success",
+  REJECTED: "destructive",
+} as const;
+
+const VISIBILITY_LABELS = {
+  PUBLIC: "منتشر",
+  PRIVATE: "غیرمنتشر",
+} as const;
+
+const EVENT_LABELS: EventLabelMap = {
+  APPROVE: "تایید",
+  REJECT: "رد",
+  REVERT_TO_PENDING: "بازگشت به بررسی",
+  HIDE: "عدم نمایش",
+  UNHIDE: "نمایش",
+  SYSTEM_AUTO_UNPUBLISH: "عدم نمایش سیستمی",
+};
+
+const SKILL_LABELS = new Map(SKILLS.map((skill) => [skill.key, skill.label] as const));
+
+function getDisplayName(
+  stageName?: string | null,
+  firstName?: string | null,
+  lastName?: string | null,
+) {
+  if (stageName && stageName.trim()) {
+    return stageName.trim();
+  }
+  const fullName = `${firstName ?? ""} ${lastName ?? ""}`.trim();
+  return fullName || "بدون نام";
+}
+
+function normalizeGallery(gallery: unknown): { url: string }[] {
+  if (!Array.isArray(gallery)) {
+    return [];
+  }
+
+  const images: { url: string }[] = [];
+  for (const entry of gallery as GalleryEntry[]) {
+    if (entry && typeof entry === "object" && typeof entry.url === "string") {
+      images.push({ url: entry.url });
+    }
+  }
+  return images;
+}
+
+function extractSocialLinks(raw: SocialLinks): string[] {
+  if (!raw || typeof raw !== "object") {
+    return [];
+  }
+
+  const links: string[] = [];
+  for (const value of Object.values(raw)) {
+    if (typeof value === "string" && value.trim().startsWith("http")) {
+      links.push(value.trim());
+    }
+  }
+  return links;
+}
+
+export default async function ModerationDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const [detail, cities] = await Promise.all([
+    getModerationDetail(params.id),
+    getCities(),
+  ]);
+
+  if (!detail) {
+    notFound();
+  }
+
+  const { profile, events } = detail;
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+  const displayName = getDisplayName(profile.stageName, profile.firstName, profile.lastName);
+  const cityName = profile.cityId ? cityMap.get(profile.cityId) ?? profile.cityId : "نامشخص";
+  const skills = Array.isArray(profile.skills)
+    ? (profile.skills as unknown[])
+        .filter((skill): skill is string => typeof skill === "string")
+        .map((key) => ({ key, label: SKILL_LABELS.get(key) ?? key }))
+    : [];
+  const gallery = normalizeGallery(profile.gallery);
+  const socialLinks = extractSocialLinks(profile.socialLinks as SocialLinks);
+
+  return (
+    <div className="space-y-6" dir="rtl">
+      <header className="flex flex-col gap-4 rounded-lg border border-border bg-background p-6 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-bold">پروفایل {displayName}</h1>
+            <p className="text-sm text-muted-foreground">شناسه پروفایل: {profile.id}</p>
+            <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+              <span>کاربر: {profile.user?.name ?? "بدون نام"}</span>
+              <span>ایمیل: {profile.user?.email ?? "نامشخص"}</span>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={STATUS_VARIANTS[profile.moderationStatus]}>
+              {STATUS_LABELS[profile.moderationStatus]}
+            </Badge>
+            <Badge variant={profile.visibility === "PUBLIC" ? "secondary" : "outline"}>
+              {VISIBILITY_LABELS[profile.visibility]}
+            </Badge>
+          </div>
+        </div>
+        <ModerationActions
+          profileId={profile.id}
+          status={profile.moderationStatus}
+          visibility={profile.visibility}
+        />
+        {profile.moderationNotes ? (
+          <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+            <div className="font-medium">یادداشت اخیر:</div>
+            <p className="leading-6">{profile.moderationNotes}</p>
+          </div>
+        ) : null}
+        {profile.moderator ? (
+          <div className="text-xs text-muted-foreground">
+            آخرین بررسی توسط {profile.moderator.name ?? profile.moderator.email ?? "نامشخص"}
+            {profile.moderatedAt
+              ? ` در ${new Date(profile.moderatedAt).toLocaleString("fa-IR", {
+                  dateStyle: "short",
+                  timeStyle: "short",
+                })}`
+              : ""}
+          </div>
+        ) : null}
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>اطلاعات اصلی</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start">
+            <div className="flex-shrink-0">
+              <div className="h-32 w-32 overflow-hidden rounded-lg border border-border">
+                {profile.avatarUrl ? (
+                  <Image
+                    src={profile.avatarUrl}
+                    alt={`تصویر ${displayName}`}
+                    width={128}
+                    height={128}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center bg-muted text-xs text-muted-foreground">
+                    بدون تصویر
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="grid flex-1 grid-cols-1 gap-4 text-sm md:grid-cols-2">
+              <div>
+                <div className="text-muted-foreground">نام</div>
+                <div className="font-medium">{displayName}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">شهر</div>
+                <div className="font-medium">{cityName}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">سن</div>
+                <div className="font-medium">{profile.age ?? "نامشخص"}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">تلفن</div>
+                <div className="font-medium">{profile.phone ?? "نامشخص"}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">آدرس</div>
+                <div className="font-medium">{profile.address ?? "نامشخص"}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">تاریخ بروزرسانی</div>
+                <div className="font-medium">
+                  {new Date(profile.updatedAt).toLocaleString("fa-IR", {
+                    dateStyle: "short",
+                    timeStyle: "short",
+                  })}
+                </div>
+              </div>
+            </div>
+          </div>
+          {socialLinks.length ? (
+            <div className="space-y-2">
+              <div className="text-sm font-medium">لینک‌ها</div>
+              <div className="flex flex-wrap gap-2 text-sm">
+                {socialLinks.map((link) => (
+                  <a
+                    key={link}
+                    href={link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded-full border border-border px-3 py-1 text-muted-foreground hover:text-foreground"
+                  >
+                    {link}
+                  </a>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>زندگی‌نامه و مهارت‌ها</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div>
+            <div className="text-muted-foreground">بیوگرافی</div>
+            <p className="leading-7 text-foreground">
+              {profile.bio ?? "اطلاعاتی ثبت نشده است."}
+            </p>
+          </div>
+          <div>
+            <div className="text-muted-foreground">مهارت‌ها</div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {skills.length ? (
+                skills.map((skill) => (
+                  <Badge key={skill.key} variant="outline">
+                    {skill.label}
+                  </Badge>
+                ))
+              ) : (
+                <span className="text-xs text-muted-foreground">مهارتی ثبت نشده است.</span>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>گالری</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {gallery.length ? (
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+              {gallery.map((item) => (
+                <div key={item.url} className="overflow-hidden rounded-lg border border-border">
+                  <Image
+                    src={item.url}
+                    alt={`تصویر ${displayName}`}
+                    width={320}
+                    height={240}
+                    className="h-40 w-full object-cover"
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">تصویری ثبت نشده است.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>رویدادهای ممیزی اخیر</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {events.length ? (
+            events.map((event) => (
+              <div
+                key={event.id}
+                className="rounded-lg border border-border/60 bg-muted/30 p-4 text-sm"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="font-medium">{EVENT_LABELS[event.action]}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {new Date(event.createdAt).toLocaleString("fa-IR", {
+                      dateStyle: "short",
+                      timeStyle: "short",
+                    })}
+                  </div>
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  توسط {event.actor?.name ?? event.actor?.email ?? "سیستم"}
+                </div>
+                {event.reason ? (
+                  <div className="mt-2 text-sm leading-6">{event.reason}</div>
+                ) : null}
+              </div>
+            ))
+          ) : (
+            <p className="text-sm text-muted-foreground">رویدادی ثبت نشده است.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/admin/moderation/_components/moderation-actions.tsx
+++ b/apps/web/app/admin/moderation/_components/moderation-actions.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+
+import {
+  approveAction,
+  hideAction,
+  rejectAction,
+  revertPendingAction,
+  unhideAction,
+} from "../actions";
+
+type Props = {
+  profileId: string;
+  status: "PENDING" | "APPROVED" | "REJECTED";
+  visibility: "PUBLIC" | "PRIVATE";
+};
+
+export function ModerationActions({ profileId, status, visibility }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [revertOpen, setRevertOpen] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+  const [revertNote, setRevertNote] = useState("");
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const handleApprove = () => {
+    startTransition(async () => {
+      const result = await approveAction(profileId);
+      if (!result?.ok) {
+        toast({ variant: "destructive", description: result?.error ?? "خطا در تایید پروفایل." });
+        return;
+      }
+
+      toast({ description: "پروفایل تایید شد." });
+      router.refresh();
+    });
+  };
+
+  const handleReject = () => {
+    const trimmed = rejectReason.trim();
+    if (!trimmed) {
+      toast({ variant: "destructive", description: "لطفاً دلیل رد را وارد کنید." });
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await rejectAction(profileId, trimmed);
+      if (!result?.ok) {
+        toast({ variant: "destructive", description: result?.error ?? "خطا در رد پروفایل." });
+        return;
+      }
+
+      toast({ description: "پروفایل رد شد." });
+      setRejectOpen(false);
+      setRejectReason("");
+      router.refresh();
+    });
+  };
+
+  const handleRevert = () => {
+    const trimmed = revertNote.trim();
+
+    startTransition(async () => {
+      const result = await revertPendingAction(profileId, trimmed ? trimmed : undefined);
+      if (!result?.ok) {
+        toast({ variant: "destructive", description: result?.error ?? "خطا در بازگردانی پروفایل." });
+        return;
+      }
+
+      toast({ description: "پروفایل به حالت بررسی بازگشت." });
+      setRevertOpen(false);
+      setRevertNote("");
+      router.refresh();
+    });
+  };
+
+  const handleVisibility = () => {
+    startTransition(async () => {
+      const result =
+        visibility === "PUBLIC" ? await hideAction(profileId) : await unhideAction(profileId);
+
+      if (!result?.ok) {
+        toast({ variant: "destructive", description: result?.error ?? "خطا در بروزرسانی نمایش." });
+        return;
+      }
+
+      toast({ description: visibility === "PUBLIC" ? "پروفایل مخفی شد." : "پروفایل نمایش داده شد." });
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2" dir="rtl">
+      <Button onClick={handleApprove} disabled={isPending}>
+        تایید
+      </Button>
+      <Button variant="outline" onClick={() => setRejectOpen(true)} disabled={isPending}>
+        رد با دلیل
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => setRevertOpen(true)}
+        disabled={isPending || status === "PENDING"}
+      >
+        بازگردانی به بررسی
+      </Button>
+      <Button variant="outline" onClick={handleVisibility} disabled={isPending}>
+        {visibility === "PUBLIC" ? "عدم نمایش" : "نمایش"}
+      </Button>
+
+      <Dialog open={rejectOpen} onOpenChange={(open) => (!open ? setRejectOpen(false) : null)}>
+        <DialogContent dir="rtl">
+          <DialogHeader>
+            <DialogTitle>رد پروفایل</DialogTitle>
+            <DialogDescription>دلیل رد پروفایل را وارد کنید.</DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={rejectReason}
+            onChange={(event) => setRejectReason(event.target.value)}
+            placeholder="دلیل رد..."
+            rows={5}
+          />
+          <DialogFooter className="justify-end gap-2">
+            <Button variant="outline" onClick={() => setRejectOpen(false)} disabled={isPending}>
+              انصراف
+            </Button>
+            <Button onClick={handleReject} disabled={isPending}>
+              ثبت رد
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={revertOpen} onOpenChange={(open) => (!open ? setRevertOpen(false) : null)}>
+        <DialogContent dir="rtl">
+          <DialogHeader>
+            <DialogTitle>بازگردانی به بررسی</DialogTitle>
+            <DialogDescription>در صورت نیاز یادداشتی برای تیم خود وارد کنید.</DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={revertNote}
+            onChange={(event) => setRevertNote(event.target.value)}
+            placeholder="یادداشت اختیاری..."
+            rows={4}
+          />
+          <DialogFooter className="justify-end gap-2">
+            <Button variant="outline" onClick={() => setRevertOpen(false)} disabled={isPending}>
+              انصراف
+            </Button>
+            <Button onClick={handleRevert} disabled={isPending}>
+              بازگردانی
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/app/admin/moderation/_components/moderation-table.tsx
+++ b/apps/web/app/admin/moderation/_components/moderation-table.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState, useTransition } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+
+import {
+  approveAction,
+  bulkAction,
+  hideAction,
+  rejectAction,
+  unhideAction,
+} from "../actions";
+
+type ModerationRow = {
+  id: string;
+  displayName: string;
+  cityName: string;
+  age: number | null;
+  skills: Array<{ key: string; label: string }>;
+  avatarUrl: string | null;
+  visibility: "PUBLIC" | "PRIVATE";
+  moderationStatus: "PENDING" | "APPROVED" | "REJECTED";
+  updatedAt: string;
+};
+
+type Props = {
+  rows: ModerationRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+type RejectDialogState = {
+  ids: string[];
+  open: boolean;
+};
+
+const STATUS_LABELS: Record<ModerationRow["moderationStatus"], string> = {
+  PENDING: "در انتظار بررسی",
+  APPROVED: "تایید شده",
+  REJECTED: "رد شده",
+};
+
+const STATUS_VARIANTS: Record<ModerationRow["moderationStatus"], "warning" | "success" | "destructive"> = {
+  PENDING: "warning",
+  APPROVED: "success",
+  REJECTED: "destructive",
+};
+
+const VISIBILITY_LABELS: Record<ModerationRow["visibility"], string> = {
+  PUBLIC: "منتشر",
+  PRIVATE: "غیرمنتشر",
+};
+
+export function ModerationTable({ rows, total, page, pageSize }: Props) {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [rejectDialog, setRejectDialog] = useState<RejectDialogState>({ ids: [], open: false });
+  const [rejectReason, setRejectReason] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    setSelectedIds((current) => current.filter((id) => rows.some((row) => row.id === id)));
+  }, [rows]);
+
+  const allSelected = useMemo(() => {
+    return rows.length > 0 && selectedIds.length === rows.length;
+  }, [rows.length, selectedIds.length]);
+
+  const toggleSelection = (id: string) => {
+    setSelectedIds((current) =>
+      current.includes(id) ? current.filter((item) => item !== id) : [...current, id],
+    );
+  };
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds([]);
+    } else {
+      setSelectedIds(rows.map((row) => row.id));
+    }
+  };
+
+  const handleApprove = (ids: string[]) => {
+    if (!ids.length) return;
+
+    startTransition(async () => {
+      let result;
+      if (ids.length === 1) {
+        result = await approveAction(ids[0]);
+      } else {
+        result = await bulkAction({ type: "APPROVE", ids });
+      }
+
+      if (!result?.ok) {
+        toast({ variant: "destructive", description: result?.error ?? "خطا در تایید پروفایل." });
+        return;
+      }
+
+      toast({ description: "پروفایل‌ها تایید شدند." });
+      setSelectedIds([]);
+      router.refresh();
+    });
+  };
+
+  const handleVisibility = (ids: string[], type: "HIDE" | "UNHIDE") => {
+    if (!ids.length) return;
+
+    startTransition(async () => {
+      let result;
+      if (ids.length === 1) {
+        result = type === "HIDE" ? await hideAction(ids[0]) : await unhideAction(ids[0]);
+      } else {
+        result = await bulkAction({ type, ids });
+      }
+
+      if (!result?.ok) {
+        toast({ variant: "destructive", description: result?.error ?? "خطا در بروزرسانی نمایش." });
+        return;
+      }
+
+      toast({ description: type === "HIDE" ? "پروفایل‌ها مخفی شدند." : "پروفایل‌ها نمایش داده شدند." });
+      setSelectedIds([]);
+      router.refresh();
+    });
+  };
+
+  const submitReject = (ids: string[], reason: string) => {
+    const trimmed = reason.trim();
+    if (!ids.length || !trimmed) {
+      toast({ variant: "destructive", description: "وارد کردن دلیل رد الزامی است." });
+      return;
+    }
+
+    startTransition(async () => {
+      let result;
+      if (ids.length === 1) {
+        result = await rejectAction(ids[0], trimmed);
+      } else {
+        result = await bulkAction({ type: "REJECT", ids, payload: { reason: trimmed } });
+      }
+
+      if (!result?.ok) {
+        toast({ variant: "destructive", description: result?.error ?? "خطا در رد پروفایل." });
+        return;
+      }
+
+      toast({ description: "پروفایل‌ها رد شدند." });
+      setSelectedIds([]);
+      setRejectDialog({ ids: [], open: false });
+      setRejectReason("");
+      router.refresh();
+    });
+  };
+
+  const openRejectDialog = (ids: string[]) => {
+    setRejectReason("");
+    setRejectDialog({ ids, open: true });
+  };
+
+  const closeRejectDialog = () => {
+    setRejectDialog({ ids: [], open: false });
+    setRejectReason("");
+  };
+
+  const totalStart = (page - 1) * pageSize + 1;
+  const totalEnd = Math.min(total, page * pageSize);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+        <span>
+          نمایش {rows.length ? `${totalStart}-${totalEnd}` : 0} از {total} پروفایل
+        </span>
+        {selectedIds.length ? (
+          <span>{selectedIds.length} پروفایل انتخاب شده</span>
+        ) : null}
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border bg-background shadow-sm">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-12 text-center">
+                <input
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={toggleSelectAll}
+                  className="h-4 w-4 accent-primary"
+                  aria-label="انتخاب همه"
+                />
+              </TableHead>
+              <TableHead>کاربر</TableHead>
+              <TableHead>شهر</TableHead>
+              <TableHead>سن</TableHead>
+              <TableHead>مهارت‌ها</TableHead>
+              <TableHead>نمایش</TableHead>
+              <TableHead>وضعیت ممیزی</TableHead>
+              <TableHead>آخرین بروزرسانی</TableHead>
+              <TableHead className="text-left">اقدامات</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={9} className="py-10 text-center text-muted-foreground">
+                  موردی برای نمایش یافت نشد.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => (
+                <TableRow key={row.id} data-state={selectedIds.includes(row.id) ? "selected" : undefined}>
+                  <TableCell className="text-center">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.includes(row.id)}
+                      onChange={() => toggleSelection(row.id)}
+                      className="h-4 w-4 accent-primary"
+                      aria-label={`انتخاب ${row.displayName}`}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <div className="h-12 w-12 overflow-hidden rounded-md border border-border">
+                        {row.avatarUrl ? (
+                          <Image
+                            src={row.avatarUrl}
+                            alt={`تصویر ${row.displayName}`}
+                            width={48}
+                            height={48}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center bg-muted text-xs text-muted-foreground">
+                            بدون تصویر
+                          </div>
+                        )}
+                      </div>
+                      <div className="space-y-1">
+                        <div className="font-medium">{row.displayName}</div>
+                        <div className="text-xs text-muted-foreground">{row.id}</div>
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell>{row.cityName}</TableCell>
+                  <TableCell>{row.age ?? "--"}</TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {row.skills.length ? (
+                        row.skills.map((skill) => (
+                          <Badge key={skill.key} variant="outline">
+                            {skill.label}
+                          </Badge>
+                        ))
+                      ) : (
+                        <span className="text-xs text-muted-foreground">بدون مهارت</span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={row.visibility === "PUBLIC" ? "secondary" : "outline"}>
+                      {VISIBILITY_LABELS[row.visibility]}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={STATUS_VARIANTS[row.moderationStatus]}>
+                      {STATUS_LABELS[row.moderationStatus]}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {new Date(row.updatedAt).toLocaleString("fa-IR", {
+                      dateStyle: "short",
+                      timeStyle: "short",
+                    })}
+                  </TableCell>
+                  <TableCell className="space-x-1 space-x-reverse text-left">
+                    <Button
+                      variant="default"
+                      size="sm"
+                      disabled={isPending}
+                      onClick={() => handleApprove([row.id])}
+                    >
+                      تایید
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={isPending}
+                      onClick={() => openRejectDialog([row.id])}
+                    >
+                      رد با دلیل
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={isPending}
+                      onClick={() =>
+                        handleVisibility([row.id], row.visibility === "PUBLIC" ? "HIDE" : "UNHIDE")
+                      }
+                    >
+                      {row.visibility === "PUBLIC" ? "عدم نمایش" : "نمایش"}
+                    </Button>
+                    <Button variant="secondary" size="sm" asChild>
+                      <Link href={`/admin/moderation/${row.id}`}>جزئیات</Link>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {selectedIds.length ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-background p-4">
+          <div className="text-sm font-medium">اقدامات گروهی</div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              disabled={isPending}
+              onClick={() => handleApprove(selectedIds)}
+            >
+              تایید
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => openRejectDialog(selectedIds)}
+            >
+              رد با دلیل
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => handleVisibility(selectedIds, "HIDE")}
+            >
+              عدم نمایش
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => handleVisibility(selectedIds, "UNHIDE")}
+            >
+              نمایش
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <Dialog open={rejectDialog.open} onOpenChange={(open) => (!open ? closeRejectDialog() : null)}>
+        <DialogContent dir="rtl">
+          <DialogHeader>
+            <DialogTitle>رد پروفایل</DialogTitle>
+            <DialogDescription>لطفاً دلیل رد پروفایل را وارد کنید.</DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={rejectReason}
+            onChange={(event) => setRejectReason(event.target.value)}
+            placeholder="دلیل رد..."
+            rows={5}
+          />
+          <DialogFooter className="justify-end gap-2">
+            <Button type="button" variant="outline" onClick={closeRejectDialog} disabled={isPending}>
+              انصراف
+            </Button>
+            <Button
+              type="button"
+              onClick={() => submitReject(rejectDialog.ids, rejectReason)}
+              disabled={isPending}
+            >
+              ثبت رد
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/app/admin/moderation/actions.ts
+++ b/apps/web/app/admin/moderation/actions.ts
@@ -1,0 +1,173 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { getServerAuthSession } from "@/lib/auth/session";
+import {
+  approveProfile,
+  hideProfile,
+  rejectProfile,
+  revertToPending,
+  unhideProfile,
+} from "@/lib/profile/moderation";
+
+const AUTH_ERROR = "دسترسی مجاز نیست.";
+const GENERIC_ERROR = "خطایی رخ داد. لطفاً دوباره تلاش کنید.";
+
+const idSchema = z.string().cuid();
+const reasonSchema = z
+  .string({ invalid_type_error: "متن وارد شده معتبر نیست." })
+  .trim()
+  .min(1, "وارد کردن دلیل الزامی است.")
+  .max(2000, "حداکثر ۲۰۰۰ کاراکتر مجاز است.");
+
+const optionalNoteSchema = z
+  .string({ invalid_type_error: "متن وارد شده معتبر نیست." })
+  .trim()
+  .max(2000, "حداکثر ۲۰۰۰ کاراکتر مجاز است.")
+  .transform((value) => (value.length ? value : undefined));
+
+async function ensureAdmin() {
+  const session = await getServerAuthSession();
+
+  if (!session?.user?.id || session.user.role !== "ADMIN") {
+    throw new Error(AUTH_ERROR);
+  }
+
+  return session.user;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    return error.issues[0]?.message ?? GENERIC_ERROR;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return GENERIC_ERROR;
+}
+
+async function revalidateModerationPages(profileId: string) {
+  await revalidatePath("/admin/moderation");
+  await revalidatePath(`/admin/moderation/${profileId}`);
+}
+
+export async function approveAction(profileId: string, note?: string) {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(profileId);
+    const parsedNote = note !== undefined ? optionalNoteSchema.parse(note) : undefined;
+
+    await approveProfile(id, admin.id, parsedNote);
+    await revalidateModerationPages(id);
+
+    return { ok: true } as const;
+  } catch (error) {
+    return { ok: false, error: getErrorMessage(error) } as const;
+  }
+}
+
+export async function rejectAction(profileId: string, reason: string) {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(profileId);
+    const parsedReason = reasonSchema.parse(reason);
+
+    await rejectProfile(id, admin.id, parsedReason);
+    await revalidateModerationPages(id);
+
+    return { ok: true } as const;
+  } catch (error) {
+    return { ok: false, error: getErrorMessage(error) } as const;
+  }
+}
+
+export async function revertPendingAction(profileId: string, note?: string) {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(profileId);
+    const parsedNote = note !== undefined ? optionalNoteSchema.parse(note) : undefined;
+
+    await revertToPending(id, admin.id, parsedNote);
+    await revalidateModerationPages(id);
+
+    return { ok: true } as const;
+  } catch (error) {
+    return { ok: false, error: getErrorMessage(error) } as const;
+  }
+}
+
+export async function hideAction(profileId: string) {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(profileId);
+
+    await hideProfile(id, admin.id);
+    await revalidateModerationPages(id);
+
+    return { ok: true } as const;
+  } catch (error) {
+    return { ok: false, error: getErrorMessage(error) } as const;
+  }
+}
+
+export async function unhideAction(profileId: string) {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(profileId);
+
+    await unhideProfile(id, admin.id);
+    await revalidateModerationPages(id);
+
+    return { ok: true } as const;
+  } catch (error) {
+    return { ok: false, error: getErrorMessage(error) } as const;
+  }
+}
+
+const bulkActionSchema = z.object({
+  type: z.enum(["APPROVE", "REJECT", "HIDE", "UNHIDE"]),
+  ids: z.array(z.string().cuid()).min(1, "حداقل یک پروفایل را انتخاب کنید."),
+  payload: z
+    .object({
+      reason: reasonSchema.optional(),
+      note: optionalNoteSchema.optional(),
+    })
+    .optional(),
+});
+
+export async function bulkAction(input: {
+  type: "APPROVE" | "REJECT" | "HIDE" | "UNHIDE";
+  ids: string[];
+  payload?: { reason?: string; note?: string };
+}) {
+  try {
+    const admin = await ensureAdmin();
+    const parsed = bulkActionSchema.parse(input);
+
+    if (parsed.type === "REJECT" && !parsed.payload?.reason) {
+      throw new Error("وارد کردن دلیل رد الزامی است.");
+    }
+
+    for (const id of parsed.ids) {
+      if (parsed.type === "APPROVE") {
+        await approveProfile(id, admin.id, parsed.payload?.note);
+      } else if (parsed.type === "REJECT") {
+        await rejectProfile(id, admin.id, parsed.payload?.reason ?? "");
+      } else if (parsed.type === "HIDE") {
+        await hideProfile(id, admin.id);
+      } else if (parsed.type === "UNHIDE") {
+        await unhideProfile(id, admin.id);
+      }
+
+      await revalidatePath(`/admin/moderation/${id}`);
+    }
+
+    await revalidatePath("/admin/moderation");
+
+    return { ok: true } as const;
+  } catch (error) {
+    return { ok: false, error: getErrorMessage(error) } as const;
+  }
+}

--- a/apps/web/app/admin/moderation/page.tsx
+++ b/apps/web/app/admin/moderation/page.tsx
@@ -1,0 +1,343 @@
+import { Suspense } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { getCities } from "@/lib/location/cities";
+import { listProfilesForModeration } from "@/lib/profile/moderation";
+import { SKILLS } from "@/lib/profile/skills";
+
+import { ModerationTable } from "./_components/moderation-table";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+type SkillOption = {
+  key: string;
+  label: string;
+};
+
+const STATUS_OPTIONS = [
+  { value: "ALL", label: "همه وضعیت‌ها" },
+  { value: "PENDING", label: "در انتظار بررسی" },
+  { value: "APPROVED", label: "تایید شده" },
+  { value: "REJECTED", label: "رد شده" },
+] as const;
+
+const VISIBILITY_OPTIONS = [
+  { value: "ALL", label: "همه نمایش‌ها" },
+  { value: "PUBLIC", label: "منتشر" },
+  { value: "PRIVATE", label: "غیرمنتشر" },
+] as const;
+
+const AVATAR_OPTIONS = [
+  { value: "", label: "همه" },
+  { value: "with", label: "دارای تصویر" },
+  { value: "without", label: "بدون تصویر" },
+] as const;
+
+const PAGE_SIZE = 20;
+
+function getParam(params: SearchParams, key: string): string | undefined {
+  const value = params[key];
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function parseDateParam(value: string | undefined): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function normalizeSkills(): SkillOption[] {
+  return SKILLS.map((skill) => ({ key: skill.key, label: skill.label }));
+}
+
+function getDisplayName(
+  stageName?: string | null,
+  firstName?: string | null,
+  lastName?: string | null,
+) {
+  if (stageName && stageName.trim()) {
+    return stageName.trim();
+  }
+  const fullName = `${firstName ?? ""} ${lastName ?? ""}`.trim();
+  return fullName || "بدون نام";
+}
+
+export default async function ModerationPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const statusParam = getParam(searchParams, "status");
+  const visibilityParam = getParam(searchParams, "visibility");
+  const hasAvatarParam = getParam(searchParams, "avatar");
+  const cityParam = getParam(searchParams, "city");
+  const skillParam = getParam(searchParams, "skill");
+  const fromParam = getParam(searchParams, "from");
+  const toParam = getParam(searchParams, "to");
+  const queryParam = getParam(searchParams, "q");
+  const pageParam = Number.parseInt(getParam(searchParams, "page") ?? "1", 10);
+
+  const filters = {
+    status:
+      statusParam === "PENDING" || statusParam === "APPROVED" || statusParam === "REJECTED"
+        ? statusParam
+        : undefined,
+    visibility:
+      visibilityParam === "PUBLIC" || visibilityParam === "PRIVATE"
+        ? visibilityParam
+        : undefined,
+    hasAvatar:
+      hasAvatarParam === "with"
+        ? true
+        : hasAvatarParam === "without"
+          ? false
+          : undefined,
+    cityId: cityParam && cityParam.trim() ? cityParam.trim() : undefined,
+    skill: skillParam && skillParam.trim() ? skillParam.trim() : undefined,
+    from: parseDateParam(fromParam),
+    to: parseDateParam(toParam),
+    q: queryParam?.trim() ? queryParam.trim() : undefined,
+  } satisfies Parameters<typeof listProfilesForModeration>[0];
+
+  const page = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
+
+  const [listResult, cities] = await Promise.all([
+    listProfilesForModeration(filters, { page, pageSize: PAGE_SIZE }),
+    getCities(),
+  ]);
+
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+  const skillOptions = normalizeSkills();
+
+  const rows = listResult.items.map((item) => {
+    const rawSkills = Array.isArray(item.skills) ? (item.skills as unknown[]) : [];
+    const skills = rawSkills
+      .filter((value): value is string => typeof value === "string")
+      .map((key) => {
+        const skill = skillOptions.find((option) => option.key === key);
+        return {
+          key,
+          label: skill?.label ?? key,
+        };
+      });
+
+    return {
+      id: item.id,
+      displayName: getDisplayName(item.stageName, item.firstName, item.lastName),
+      cityName: item.cityId ? cityMap.get(item.cityId) ?? item.cityId : "نامشخص",
+      age: item.age,
+      skills,
+      avatarUrl: typeof item.avatarUrl === "string" ? item.avatarUrl : null,
+      visibility: item.visibility,
+      moderationStatus: item.moderationStatus,
+      updatedAt: item.updatedAt.toISOString(),
+    };
+  });
+
+  const totalPages = Math.max(1, Math.ceil(listResult.total / listResult.pageSize));
+
+  return (
+    <div className="space-y-6" dir="rtl">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold">پنل مدیریت پروفایل‌ها</h1>
+        <p className="text-sm text-muted-foreground">
+          مدیریت وضعیت انتشار و ممیزی پروفایل‌های کاربران.
+        </p>
+      </header>
+
+      <section className="rounded-lg border border-border bg-background p-4 shadow-sm">
+        <form className="grid grid-cols-1 gap-4 md:grid-cols-4" method="get">
+          <input type="hidden" name="page" value="1" />
+          <div className="space-y-2">
+            <Label htmlFor="status">وضعیت</Label>
+            <Select defaultValue={statusParam ?? "ALL"} name="status">
+              <SelectTrigger id="status">
+                <SelectValue placeholder="وضعیت" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                {STATUS_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="visibility">نمایش</Label>
+            <Select defaultValue={visibilityParam ?? "ALL"} name="visibility">
+              <SelectTrigger id="visibility">
+                <SelectValue placeholder="نمایش" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                {VISIBILITY_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="avatar">تصویر پروفایل</Label>
+            <Select defaultValue={hasAvatarParam ?? ""} name="avatar">
+              <SelectTrigger id="avatar">
+                <SelectValue placeholder="تصویر" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                {AVATAR_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="city">شهر</Label>
+            <Select defaultValue={cityParam ?? ""} name="city">
+              <SelectTrigger id="city">
+                <SelectValue placeholder="همه شهرها" />
+              </SelectTrigger>
+              <SelectContent align="end" className="max-h-64">
+                <SelectItem value="">همه شهرها</SelectItem>
+                {cities.map((city) => (
+                  <SelectItem key={city.id} value={city.id}>
+                    {city.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="skill">مهارت</Label>
+            <Select defaultValue={skillParam ?? ""} name="skill">
+              <SelectTrigger id="skill">
+                <SelectValue placeholder="همه مهارت‌ها" />
+              </SelectTrigger>
+              <SelectContent align="end" className="max-h-64">
+                <SelectItem value="">همه مهارت‌ها</SelectItem>
+                {skillOptions.map((skill) => (
+                  <SelectItem key={skill.key} value={skill.key}>
+                    {skill.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="from">از تاریخ</Label>
+            <Input id="from" name="from" type="date" defaultValue={fromParam ?? ""} />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="to">تا تاریخ</Label>
+            <Input id="to" name="to" type="date" defaultValue={toParam ?? ""} />
+          </div>
+
+          <div className="space-y-2 md:col-span-2">
+            <Label htmlFor="q">جستجو</Label>
+            <Input
+              id="q"
+              name="q"
+              placeholder="نام، نام هنری یا توضیحات..."
+              defaultValue={queryParam ?? ""}
+            />
+          </div>
+
+          <div className="flex items-end gap-2 md:col-span-2">
+            <Button type="submit" className="w-full md:w-auto">
+              اعمال فیلتر
+            </Button>
+            <Button variant="outline" className="w-full md:w-auto" asChild>
+              <a href="/admin/moderation">پاکسازی</a>
+            </Button>
+          </div>
+        </form>
+      </section>
+
+      <Suspense fallback={<div className="text-sm text-muted-foreground">در حال بارگذاری...</div>}>
+        <ModerationTable
+          rows={rows}
+          total={listResult.total}
+          page={listResult.page}
+          pageSize={listResult.pageSize}
+        />
+      </Suspense>
+
+      <PaginationControls
+        totalPages={totalPages}
+        currentPage={listResult.page}
+        searchParams={searchParams}
+      />
+    </div>
+  );
+}
+
+type PaginationProps = {
+  totalPages: number;
+  currentPage: number;
+  searchParams: SearchParams;
+};
+
+function PaginationControls({ totalPages, currentPage, searchParams }: PaginationProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const createLink = (page: number) => {
+    const params = new URLSearchParams();
+    Object.entries(searchParams).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        if (value[0]) {
+          params.set(key, value[0]);
+        }
+      } else if (value) {
+        params.set(key, value);
+      }
+    });
+    params.set("page", page.toString());
+    return `?${params.toString()}`;
+  };
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-border bg-background p-4 text-sm">
+      <span>
+        صفحه {currentPage} از {totalPages}
+      </span>
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={currentPage <= 1}
+          asChild
+        >
+          <a href={createLink(Math.max(1, currentPage - 1))}>قبلی</a>
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={currentPage >= totalPages}
+          asChild
+        >
+          <a href={createLink(Math.min(totalPages, currentPage + 1))}>بعدی</a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/profiles/[id]/page.tsx
+++ b/apps/web/app/profiles/[id]/page.tsx
@@ -72,6 +72,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     where: { id: params.id },
     select: {
       visibility: true,
+      moderationStatus: true,
       stageName: true,
       firstName: true,
       lastName: true,
@@ -80,7 +81,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
   });
 
-  if (!profile || profile.visibility !== "PUBLIC") {
+  if (
+    !profile ||
+    profile.visibility !== "PUBLIC" ||
+    profile.moderationStatus !== "APPROVED"
+  ) {
     return {};
   }
 
@@ -104,7 +109,11 @@ export default async function PublicProfilePage({ params }: Props) {
     where: { id: params.id },
   });
 
-  if (!profile || profile.visibility !== "PUBLIC") {
+  if (
+    !profile ||
+    profile.visibility !== "PUBLIC" ||
+    profile.moderationStatus !== "APPROVED"
+  ) {
     notFound();
   }
 

--- a/apps/web/lib/profile/enforcement.ts
+++ b/apps/web/lib/profile/enforcement.ts
@@ -83,6 +83,15 @@ export async function enforceUserProfileVisibility(
       },
     });
 
+    await prisma.moderationEvent.create({
+      data: {
+        profileId: profile.id,
+        actorId: null,
+        action: "SYSTEM_AUTO_UNPUBLISH",
+        reason: publishability.reason ?? "PUBLISHABILITY_REVOKED",
+      },
+    });
+
     await revalidateProfilePaths(profile.id);
 
     console.info("[enforcement] auto_unpublished", {

--- a/apps/web/lib/profile/moderation.ts
+++ b/apps/web/lib/profile/moderation.ts
@@ -1,0 +1,481 @@
+import { revalidatePath } from "next/cache";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+const PROFILE_PATHS_TO_REVALIDATE = [
+  "/profiles",
+  "/dashboard/profile",
+];
+
+export const MODERATION_PROFILE_SELECT = {
+  id: true,
+  userId: true,
+  firstName: true,
+  lastName: true,
+  stageName: true,
+  bio: true,
+  avatarUrl: true,
+  cityId: true,
+  phone: true,
+  address: true,
+  gallery: true,
+  skills: true,
+  visibility: true,
+  moderationStatus: true,
+  moderationNotes: true,
+  moderatedBy: true,
+  moderatedAt: true,
+  updatedAt: true,
+} satisfies Prisma.ProfileSelect;
+
+export type ModerationProfileSnapshot = Prisma.ProfileGetPayload<{
+  select: typeof MODERATION_PROFILE_SELECT;
+}>;
+
+const CRITICAL_JSON_KEYS = new Set<keyof ModerationProfileSnapshot>([
+  "gallery",
+  "skills",
+]);
+
+const CRITICAL_FIELD_KEYS: Array<keyof ModerationProfileSnapshot> = [
+  "firstName",
+  "lastName",
+  "stageName",
+  "bio",
+  "avatarUrl",
+  "cityId",
+  "phone",
+  "address",
+  "gallery",
+  "skills",
+];
+
+function normalizeJson(value: unknown) {
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function hasCriticalDifferences(
+  previous: ModerationProfileSnapshot | null,
+  next: ModerationProfileSnapshot | null,
+): boolean {
+  if (!previous || !next) {
+    return false;
+  }
+
+  if (previous.moderationStatus !== "APPROVED") {
+    return false;
+  }
+
+  for (const key of CRITICAL_FIELD_KEYS) {
+    const oldValue = previous[key];
+    const newValue = next[key];
+
+    if (CRITICAL_JSON_KEYS.has(key)) {
+      if (normalizeJson(oldValue) !== normalizeJson(newValue)) {
+        return true;
+      }
+    } else {
+      if ((oldValue ?? null) !== (newValue ?? null)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+async function revalidateProfilePaths(profileId: string) {
+  const paths = [
+    `/profiles/${profileId}`,
+    ...PROFILE_PATHS_TO_REVALIDATE,
+  ];
+
+  for (const path of paths) {
+    try {
+      await revalidatePath(path);
+    } catch (error) {
+      console.warn("[moderation] revalidate_failed", {
+        path,
+        error,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+}
+
+export async function maybeMarkPendingOnCriticalEdit({
+  old,
+  next,
+  actorId,
+}: {
+  old: ModerationProfileSnapshot | null;
+  next: ModerationProfileSnapshot | null;
+  actorId?: string | null;
+}): Promise<boolean> {
+  if (!old || !next) {
+    return false;
+  }
+
+  if (!hasCriticalDifferences(old, next)) {
+    return false;
+  }
+
+  const [, event] = await prisma.$transaction([
+    prisma.profile.update({
+      where: { id: next.id },
+      data: {
+        moderationStatus: "PENDING",
+        moderationNotes: null,
+        moderatedBy: null,
+        moderatedAt: null,
+      },
+    }),
+    prisma.moderationEvent.create({
+      data: {
+        profileId: next.id,
+        actorId: actorId ?? null,
+        action: "REVERT_TO_PENDING",
+        reason: null,
+      },
+    }),
+  ]);
+
+  await revalidateProfilePaths(next.id);
+
+  return Boolean(event);
+}
+
+export async function approveProfile(
+  profileId: string,
+  actorId: string,
+  note?: string,
+): Promise<ModerationProfileSnapshot> {
+  const cleanedNote = note?.trim() ? note.trim() : null;
+  const now = new Date();
+
+  const [profile] = await prisma.$transaction([
+    prisma.profile.update({
+      where: { id: profileId },
+      data: {
+        moderationStatus: "APPROVED",
+        moderationNotes: cleanedNote,
+        moderatedBy: actorId,
+        moderatedAt: now,
+      },
+      select: MODERATION_PROFILE_SELECT,
+    }),
+    prisma.moderationEvent.create({
+      data: {
+        profileId,
+        actorId,
+        action: "APPROVE",
+        reason: cleanedNote,
+      },
+    }),
+  ]);
+
+  await revalidateProfilePaths(profileId);
+
+  return profile;
+}
+
+export async function rejectProfile(
+  profileId: string,
+  actorId: string,
+  reason: string,
+): Promise<ModerationProfileSnapshot> {
+  const cleanedReason = reason.trim();
+  const now = new Date();
+
+  const [profile] = await prisma.$transaction([
+    prisma.profile.update({
+      where: { id: profileId },
+      data: {
+        moderationStatus: "REJECTED",
+        moderationNotes: cleanedReason,
+        moderatedBy: actorId,
+        moderatedAt: now,
+        visibility: "PRIVATE",
+      },
+      select: MODERATION_PROFILE_SELECT,
+    }),
+    prisma.moderationEvent.create({
+      data: {
+        profileId,
+        actorId,
+        action: "REJECT",
+        reason: cleanedReason,
+      },
+    }),
+  ]);
+
+  await revalidateProfilePaths(profileId);
+
+  return profile;
+}
+
+export async function revertToPending(
+  profileId: string,
+  actorId: string,
+  note?: string,
+): Promise<ModerationProfileSnapshot> {
+  const cleanedNote = note?.trim() ? note.trim() : null;
+  const now = new Date();
+
+  const [profile] = await prisma.$transaction([
+    prisma.profile.update({
+      where: { id: profileId },
+      data: {
+        moderationStatus: "PENDING",
+        moderationNotes: cleanedNote,
+        moderatedBy: actorId,
+        moderatedAt: now,
+      },
+      select: MODERATION_PROFILE_SELECT,
+    }),
+    prisma.moderationEvent.create({
+      data: {
+        profileId,
+        actorId,
+        action: "REVERT_TO_PENDING",
+        reason: cleanedNote,
+      },
+    }),
+  ]);
+
+  await revalidateProfilePaths(profileId);
+
+  return profile;
+}
+
+export async function hideProfile(
+  profileId: string,
+  actorId: string,
+): Promise<ModerationProfileSnapshot> {
+  const [profile] = await prisma.$transaction([
+    prisma.profile.update({
+      where: { id: profileId },
+      data: {
+        visibility: "PRIVATE",
+      },
+      select: MODERATION_PROFILE_SELECT,
+    }),
+    prisma.moderationEvent.create({
+      data: {
+        profileId,
+        actorId,
+        action: "HIDE",
+        reason: null,
+      },
+    }),
+  ]);
+
+  await revalidateProfilePaths(profileId);
+
+  return profile;
+}
+
+export async function unhideProfile(
+  profileId: string,
+  actorId: string,
+): Promise<ModerationProfileSnapshot> {
+  const [profile] = await prisma.$transaction([
+    prisma.profile.update({
+      where: { id: profileId },
+      data: {
+        visibility: "PUBLIC",
+      },
+      select: MODERATION_PROFILE_SELECT,
+    }),
+    prisma.moderationEvent.create({
+      data: {
+        profileId,
+        actorId,
+        action: "UNHIDE",
+        reason: null,
+      },
+    }),
+  ]);
+
+  await revalidateProfilePaths(profileId);
+
+  return profile;
+}
+
+export type ModerationListFilters = {
+  status?: Prisma.ModerationStatus | "ALL";
+  visibility?: Prisma.ProfileVisibility | "ALL";
+  hasAvatar?: boolean;
+  cityId?: string;
+  skill?: string;
+  from?: Date;
+  to?: Date;
+  q?: string;
+};
+
+export type ModerationListResult = {
+  items: Array<
+    Prisma.ProfileGetPayload<{
+      select: {
+        id: true;
+        firstName: true;
+        lastName: true;
+        stageName: true;
+        cityId: true;
+        age: true;
+        skills: true;
+        avatarUrl: true;
+        visibility: true;
+        moderationStatus: true;
+        updatedAt: true;
+      };
+    }>
+  >;
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export async function listProfilesForModeration(
+  filters: ModerationListFilters,
+  paging: { page?: number; pageSize?: number },
+): Promise<ModerationListResult> {
+  const page = paging.page && paging.page > 0 ? paging.page : 1;
+  const pageSize = paging.pageSize && paging.pageSize > 0 ? paging.pageSize : 20;
+  const skip = (page - 1) * pageSize;
+
+  const where: Prisma.ProfileWhereInput = {};
+
+  if (filters.status && filters.status !== "ALL") {
+    where.moderationStatus = filters.status;
+  }
+
+  if (filters.visibility && filters.visibility !== "ALL") {
+    where.visibility = filters.visibility;
+  }
+
+  if (typeof filters.hasAvatar === "boolean") {
+    where.avatarUrl = filters.hasAvatar
+      ? { not: null }
+      : { equals: null };
+  }
+
+  if (filters.cityId) {
+    where.cityId = filters.cityId;
+  }
+
+  if (filters.skill) {
+    where.skills = {
+      contains: `"${filters.skill}"`,
+    } as Prisma.JsonFilter;
+  }
+
+  if (filters.from || filters.to) {
+    where.updatedAt = {
+      ...(filters.from ? { gte: filters.from } : {}),
+      ...(filters.to ? { lte: filters.to } : {}),
+    };
+  }
+
+  if (filters.q) {
+    const query = filters.q.trim();
+    if (query) {
+      where.OR = [
+        { firstName: { contains: query, mode: "insensitive" } },
+        { lastName: { contains: query, mode: "insensitive" } },
+        { stageName: { contains: query, mode: "insensitive" } },
+        { bio: { contains: query, mode: "insensitive" } },
+      ];
+    }
+  }
+
+  const [items, total] = await prisma.$transaction([
+    prisma.profile.findMany({
+      where,
+      orderBy: { updatedAt: "desc" },
+      skip,
+      take: pageSize,
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        stageName: true,
+        cityId: true,
+        age: true,
+        skills: true,
+        avatarUrl: true,
+        visibility: true,
+        moderationStatus: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.profile.count({ where }),
+  ]);
+
+  return {
+    items,
+    total,
+    page,
+    pageSize,
+  };
+}
+
+export async function getModerationDetail(profileId: string) {
+  const profile = await prisma.profile.findUnique({
+    where: { id: profileId },
+    select: {
+      ...MODERATION_PROFILE_SELECT,
+      age: true,
+      socialLinks: true,
+      moderator: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+      user: {
+        select: {
+          id: true,
+          email: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  if (!profile) {
+    return null;
+  }
+
+  const events = await prisma.moderationEvent.findMany({
+    where: { profileId },
+    orderBy: { createdAt: "desc" },
+    take: 10,
+    select: {
+      id: true,
+      action: true,
+      reason: true,
+      createdAt: true,
+      actor: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+    },
+  });
+
+  return { profile, events };
+}
+
+export { revalidateProfilePaths };

--- a/apps/web/prisma/migrations/20251007091500_admin_moderation_panel/migration.sql
+++ b/apps/web/prisma/migrations/20251007091500_admin_moderation_panel/migration.sql
@@ -1,0 +1,44 @@
+-- CreateEnum
+CREATE TYPE "ModerationStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- CreateEnum
+CREATE TYPE "ModerationAction" AS ENUM ('APPROVE', 'REJECT', 'REVERT_TO_PENDING', 'HIDE', 'UNHIDE', 'SYSTEM_AUTO_UNPUBLISH');
+
+-- AlterTable
+ALTER TABLE "Profile"
+  ADD COLUMN "moderationStatus" "ModerationStatus" NOT NULL DEFAULT 'PENDING',
+  ADD COLUMN "moderationNotes" TEXT,
+  ADD COLUMN "moderatedBy" TEXT,
+  ADD COLUMN "moderatedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "ModerationEvent" (
+  "id" TEXT NOT NULL,
+  "profileId" TEXT NOT NULL,
+  "actorId" TEXT,
+  "action" "ModerationAction" NOT NULL,
+  "reason" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ModerationEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Profile"
+  ADD CONSTRAINT "Profile_moderatedBy_fkey" FOREIGN KEY ("moderatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ModerationEvent"
+  ADD CONSTRAINT "ModerationEvent_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ModerationEvent"
+  ADD CONSTRAINT "ModerationEvent_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "Profile_moderationStatus_idx" ON "Profile"("moderationStatus");
+
+-- CreateIndex
+CREATE INDEX "Profile_updatedAt_idx" ON "Profile"("updatedAt");
+
+-- CreateIndex
+CREATE INDEX "ModerationEvent_profileId_createdAt_idx" ON "ModerationEvent"("profileId", "createdAt");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -19,6 +19,8 @@ model User {
   payments         Payment[]
   entitlements     UserEntitlement[]
   profile          Profile?
+  moderatedProfiles Profile[]        @relation("ProfileModerators")
+  moderationEvents  ModerationEvent[] @relation("ModerationActor")
 }
 
 model Profile {
@@ -45,8 +47,29 @@ model Profile {
   publishedAt DateTime?
   createdAt   DateTime           @default(now())
   updatedAt   DateTime           @updatedAt
+  moderationStatus ModerationStatus @default(PENDING)
+  moderationNotes  String?
+  moderatedBy      String?
+  moderatedAt      DateTime?
+  moderator        User?             @relation("ProfileModerators", fields: [moderatedBy], references: [id])
+  moderationEvents ModerationEvent[]
 
   @@index([visibility])
+  @@index([moderationStatus])
+  @@index([updatedAt])
+}
+
+model ModerationEvent {
+  id        String            @id @default(cuid())
+  profileId String
+  profile   Profile           @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  actorId   String?
+  actor     User?             @relation("ModerationActor", fields: [actorId], references: [id])
+  action    ModerationAction
+  reason    String?
+  createdAt DateTime          @default(now())
+
+  @@index([profileId, createdAt])
 }
 
 model Product {
@@ -196,6 +219,21 @@ enum ProfileVisibility {
 enum Role {
   USER
   ADMIN
+}
+
+enum ModerationStatus {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
+enum ModerationAction {
+  APPROVE
+  REJECT
+  REVERT_TO_PENDING
+  HIDE
+  UNHIDE
+  SYSTEM_AUTO_UNPUBLISH
 }
 
 enum InvoiceStatus {


### PR DESCRIPTION
## Summary
- extend the profile schema with moderation metadata and add the ModerationEvent audit trail
- implement moderation helpers, publish gating updates, and critical-edit checks so profiles return to pending review when needed
- build the admin moderation list and detail experiences with Persian UI, filters, bulk actions, and secure server actions

## Testing
- pnpm lint *(fails: registry access blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d5a8b0a0832798d9767e69fc5136