### PR TITLE
Fix moderation type narrowing to restore typecheck

### DIFF
--- a/apps/web/app/api/auth/signup/route.ts
+++ b/apps/web/app/api/auth/signup/route.ts
@@ -80,14 +80,13 @@ export async function POST(request: Request) {
 
     return NextResponse.json(user, { status: 201 });
   } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === "P2002"
-    ) {
-      return NextResponse.json(
-        { message: "این ایمیل قبلاً ثبت شده است." },
-        { status: 409 }
-      );
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === "P2002") {
+        return NextResponse.json(
+          { message: "این ایمیل قبلاً ثبت شده است." },
+          { status: 409 }
+        );
+      }
     }
 
     console.error("Signup failed", error);

--- a/apps/web/app/api/billing/entitlements/route.ts
+++ b/apps/web/app/api/billing/entitlements/route.ts
@@ -25,8 +25,18 @@ export async function GET(request: NextRequest) {
     },
   });
 
-  const canPublish = entitlements.find((item) => item.key === CAN_PUBLISH_PROFILE);
-  const jobCredit = entitlements.find((item) => item.key === JOB_POST_CREDIT);
+  type EntitlementResult = (typeof entitlements)[number];
+
+  let canPublish: EntitlementResult | undefined;
+  let jobCredit: EntitlementResult | undefined;
+
+  for (const entitlement of entitlements) {
+    if (entitlement.key === CAN_PUBLISH_PROFILE) {
+      canPublish = entitlement;
+    } else if (entitlement.key === JOB_POST_CREDIT) {
+      jobCredit = entitlement;
+    }
+  }
 
   return ok({
     userId,


### PR DESCRIPTION
## Summary
- ensure admin moderation actions always receive an authenticated admin with a concrete id
- tighten the signup API error handling to narrow Prisma errors safely
- avoid implicit any usage when summarising user entitlements

## Testing
- `pnpm -F @app/web typecheck` *(fails in this environment because Corepack cannot download pnpm@9.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f8f649bc8327b23d5ca6603578e8