### PR TITLE
Enforce approval and opt-in requirements for public profiles

### DIFF
--- a/apps/web/app/profiles/[id]/page.tsx
+++ b/apps/web/app/profiles/[id]/page.tsx
@@ -73,6 +73,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     select: {
       visibility: true,
       moderationStatus: true,
+      publishedAt: true,
       stageName: true,
       firstName: true,
       lastName: true,
@@ -84,7 +85,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (
     !profile ||
     profile.visibility !== "PUBLIC" ||
-    profile.moderationStatus !== "APPROVED"
+    profile.moderationStatus !== "APPROVED" ||
+    !profile.publishedAt
   ) {
     return {};
   }
@@ -109,17 +111,18 @@ export default async function PublicProfilePage({ params }: Props) {
     where: { id: params.id },
   });
 
-  if (
-    !profile ||
-    profile.visibility !== "PUBLIC" ||
-    profile.moderationStatus !== "APPROVED"
-  ) {
+  if (!profile) {
     notFound();
   }
 
   const enforcementResult = await enforceUserProfileVisibility(profile.userId);
 
-  if (enforcementResult === "auto_unpublished") {
+  if (
+    profile.visibility !== "PUBLIC" ||
+    profile.moderationStatus !== "APPROVED" ||
+    !profile.publishedAt ||
+    enforcementResult === "auto_unpublished"
+  ) {
     notFound();
   }
 


### PR DESCRIPTION
## Summary
- require approved, user-published profiles with active entitlements before showing them in the public directory
- prevent public profile pages from rendering for profiles lacking approval, publication opt-in, or entitlement
- block moderator unhide actions when users opt out of publishing or lose the required entitlement

## Testing
- pnpm --filter @app/web lint *(fails: registry fetch blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e30794d7108327ad8d9f2bbf84153a