### PR TITLE
feat: add sprint 3 job posting schema

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -10,6 +10,17 @@ The Next.js app relies on `apps/web/lib/env.ts` for typed configuration. Populat
 | `PUBLIC_BASE_URL` | ✅ | Absolute origin without a trailing slash (e.g. `http://localhost:3000`). |
 | `WEBHOOK_SHARED_SECRET` | ❌ | Optional sandbox secret; omit locally to bypass signature checks. |
 
+## Sprint 3 — Jobs
+
+- **New Prisma additions**
+  - Model: `Job`
+  - Enums: `JobStatus`, `JobModeration`
+- **Migration name**: `sprint3_jobs`
+- **Commands**
+  - Apply migration: `pnpm --filter @app/web prisma migrate dev`
+  - Regenerate client: `pnpm --filter @app/web prisma generate`
+- No new environment variables are required for this phase.
+
 Example:
 
 ```env

--- a/apps/web/prisma/migrations/20251009000000_sprint3_jobs/migration.sql
+++ b/apps/web/prisma/migrations/20251009000000_sprint3_jobs/migration.sql
@@ -1,0 +1,42 @@
+-- CreateEnum
+CREATE TYPE "JobStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'CLOSED');
+
+-- CreateEnum
+CREATE TYPE "JobModeration" AS ENUM ('PENDING', 'APPROVED', 'REJECTED', 'SUSPENDED');
+
+-- CreateTable
+CREATE TABLE "Job" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" VARCHAR(140) NOT NULL,
+    "description" TEXT NOT NULL,
+    "category" VARCHAR(64) NOT NULL,
+    "cityId" VARCHAR(64),
+    "payType" VARCHAR(32),
+    "payAmount" INTEGER,
+    "currency" VARCHAR(3),
+    "remote" BOOLEAN NOT NULL DEFAULT false,
+    "status" "JobStatus" NOT NULL DEFAULT 'DRAFT',
+    "moderation" "JobModeration" NOT NULL DEFAULT 'PENDING',
+    "featuredUntil" TIMESTAMP(3),
+    "views" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Job_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Job_status_moderation_featuredUntil_idx" ON "Job"("status", "moderation", "featuredUntil");
+
+-- CreateIndex
+CREATE INDEX "Job_category_idx" ON "Job"("category");
+
+-- CreateIndex
+CREATE INDEX "Job_cityId_idx" ON "Job"("cityId");
+
+-- CreateIndex
+CREATE INDEX "Job_title_idx" ON "Job"("title");
+
+-- AddForeignKey
+ALTER TABLE "Job" ADD CONSTRAINT "Job_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -183,6 +183,31 @@ model UserEntitlement {
   @@index([userId, key, expiresAt])
 }
 
+model Job {
+  id            String         @id @default(cuid())
+  userId        String
+  user          User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  title         String         @db.VarChar(140)
+  description   String         @db.Text
+  category      String         @db.VarChar(64)
+  cityId        String?        @db.VarChar(64)
+  payType       String?        @db.VarChar(32)
+  payAmount     Int?
+  currency      String?        @db.VarChar(3)
+  remote        Boolean        @default(false)
+  status        JobStatus      @default(DRAFT)
+  moderation    JobModeration  @default(PENDING)
+  featuredUntil DateTime?
+  views         Int            @default(0)
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+
+  @@index([status, moderation, featuredUntil])
+  @@index([category])
+  @@index([cityId])
+  @@index([title])
+}
+
 enum ProductType {
   SUBSCRIPTION
   JOB_POST
@@ -265,6 +290,19 @@ enum NotificationType {
   USER_UNPUBLISHED
   ENTITLEMENT_EXPIRED
   ENTITLEMENT_RESTORED
+}
+
+enum JobStatus {
+  DRAFT
+  PUBLISHED
+  CLOSED
+}
+
+enum JobModeration {
+  PENDING
+  APPROVED
+  REJECTED
+  SUSPENDED
 }
 
 model Notification {


### PR DESCRIPTION
## Summary
- add the Job model plus JobStatus and JobModeration enums to back the job posting workflow
- create the sprint3_jobs migration with required indexes and foreign key constraints
- document the new migration and commands in the web README

## Testing
- not run (schema-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e34ab1c5fc832798ef486c7e69281c