### PR TITLE
feat: add job credit entitlement helpers

### DIFF
--- a/apps/web/lib/entitlements/index.ts
+++ b/apps/web/lib/entitlements/index.ts
@@ -1,0 +1,1 @@
+export * from "./jobs";

--- a/apps/web/lib/entitlements/jobs.test.ts
+++ b/apps/web/lib/entitlements/jobs.test.ts
@@ -1,0 +1,397 @@
+import { EntitlementKey } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ExpiredJobCreditsError,
+  InsufficientJobCreditsError,
+  NoEntitlementError,
+  TransientConcurrencyError,
+} from "@/lib/errors";
+import {
+  assertHasJobCreditOrThrow,
+  consumeJobCreditTx,
+  getJobCreditSummary,
+  hasJobCredit,
+} from "@/lib/entitlements/jobs";
+
+const mockPrisma = {
+  userEntitlement: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+type MutableEntitlement = {
+  id: string;
+  userId: string;
+  key: EntitlementKey;
+  remainingCredits: number;
+  expiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type Barrier = {
+  wait: () => Promise<void>;
+};
+
+function createBarrier(expected: number): Barrier {
+  let count = 0;
+  let release: (() => void) | null = null;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return {
+    async wait() {
+      count += 1;
+
+      if (count >= expected) {
+        release?.();
+      }
+
+      await gate;
+    },
+  };
+}
+
+function matchesWhere(record: MutableEntitlement, where: any): boolean {
+  if (!where) {
+    return true;
+  }
+
+  const { OR, userId_key, remainingCredits, expiresAt, ...rest } = where;
+
+  if (userId_key) {
+    if (
+      record.userId !== userId_key.userId ||
+      record.key !== userId_key.key
+    ) {
+      return false;
+    }
+  }
+
+  if (typeof rest.id !== "undefined" && record.id !== rest.id) {
+    return false;
+  }
+
+  if (typeof rest.userId !== "undefined" && record.userId !== rest.userId) {
+    return false;
+  }
+
+  if (typeof rest.key !== "undefined" && record.key !== rest.key) {
+    return false;
+  }
+
+  if (
+    remainingCredits?.gt !== undefined &&
+    !(record.remainingCredits > remainingCredits.gt)
+  ) {
+    return false;
+  }
+
+  if (expiresAt !== undefined) {
+    if (expiresAt === null) {
+      if (record.expiresAt !== null) {
+        return false;
+      }
+    } else if (typeof expiresAt === "object" && "gt" in expiresAt) {
+      if (record.expiresAt === null || !(record.expiresAt > expiresAt.gt)) {
+        return false;
+      }
+    }
+  }
+
+  if (OR) {
+    if (!OR.some((clause: any) => matchesWhere(record, clause))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function selectFields(record: MutableEntitlement, select: Record<string, boolean>) {
+  return Object.fromEntries(
+    Object.entries(select)
+      .filter(([, enabled]) => enabled)
+      .map(([key]) => [key, record[key as keyof MutableEntitlement]]),
+  );
+}
+
+function createTransaction(
+  records: MutableEntitlement[],
+  options: { barrier?: Barrier } = {},
+) {
+  const userEntitlement = {
+    async findMany(args: any) {
+      if (options.barrier) {
+        await options.barrier.wait();
+      }
+
+      const filtered = records.filter((record) => matchesWhere(record, args?.where));
+
+      const ordered = Array.isArray(args?.orderBy)
+        ? [...filtered].sort((a, b) => {
+            for (const order of args.orderBy) {
+              if (order.expiresAt) {
+                const { sort, nulls } = order.expiresAt;
+                const aExp = a.expiresAt;
+                const bExp = b.expiresAt;
+
+                if (aExp === null && bExp === null) {
+                  continue;
+                }
+
+                if (aExp === null) {
+                  return nulls === "last" ? 1 : -1;
+                }
+
+                if (bExp === null) {
+                  return nulls === "last" ? -1 : 1;
+                }
+
+                if (aExp.getTime() !== bExp.getTime()) {
+                  return sort === "asc"
+                    ? aExp.getTime() - bExp.getTime()
+                    : bExp.getTime() - aExp.getTime();
+                }
+              } else if (order.updatedAt) {
+                if (a.updatedAt.getTime() !== b.updatedAt.getTime()) {
+                  return order.updatedAt === "asc"
+                    ? a.updatedAt.getTime() - b.updatedAt.getTime()
+                    : b.updatedAt.getTime() - a.updatedAt.getTime();
+                }
+              }
+            }
+
+            return 0;
+          })
+        : filtered;
+
+      if (args?.select) {
+        return ordered.map((record) => selectFields(record, args.select));
+      }
+
+      return ordered;
+    },
+    async findFirst(args: any) {
+      const results = await this.findMany({ ...args, take: 1 });
+      return results[0] ?? null;
+    },
+    async findUnique(args: any) {
+      return (
+        records.find((record) => matchesWhere(record, args?.where)) ?? null
+      );
+    },
+    async updateMany(args: any) {
+      let count = 0;
+
+      for (const record of records) {
+        if (!matchesWhere(record, args?.where)) {
+          continue;
+        }
+
+        if (args?.data?.remainingCredits?.decrement) {
+          record.remainingCredits -= args.data.remainingCredits.decrement;
+        }
+
+        record.updatedAt = new Date();
+        count += 1;
+      }
+
+      return { count };
+    },
+  };
+
+  return { userEntitlement } as unknown as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.userEntitlement.findFirst = vi.fn();
+  mockPrisma.userEntitlement.findMany = vi.fn();
+});
+
+describe("hasJobCredit", () => {
+  it("returns true when remaining > 0 and not expired", async () => {
+    mockPrisma.userEntitlement.findFirst.mockResolvedValue({ id: "ent1" });
+
+    const result = await hasJobCredit("user-1");
+
+    expect(result).toBe(true);
+    expect(mockPrisma.userEntitlement.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: "user-1" }),
+      }),
+    );
+  });
+
+  it("returns false when remaining = 0", async () => {
+    mockPrisma.userEntitlement.findFirst.mockResolvedValue(null);
+
+    const result = await hasJobCredit("user-2");
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when expired", async () => {
+    mockPrisma.userEntitlement.findFirst.mockResolvedValue(null);
+
+    const result = await hasJobCredit("user-3");
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("getJobCreditSummary", () => {
+  it("aggregates active entitlements", async () => {
+    const now = new Date();
+    mockPrisma.userEntitlement.findMany.mockResolvedValue([
+      {
+        id: "ent1",
+        expiresAt: new Date(now.getTime() + 1000),
+        remainingCredits: 1,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "ent2",
+        expiresAt: null,
+        remainingCredits: 2,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+
+    const summary = await getJobCreditSummary("user-summary");
+
+    expect(summary).toEqual({ total: 3, remaining: 3, expiresAt: null });
+  });
+
+  it("returns null when no active entitlements", async () => {
+    mockPrisma.userEntitlement.findMany.mockResolvedValue([]);
+
+    const summary = await getJobCreditSummary("user-none");
+
+    expect(summary).toBeNull();
+  });
+});
+
+describe("assertHasJobCreditOrThrow", () => {
+  it("throws when no entitlement exists", async () => {
+    mockPrisma.userEntitlement.findMany.mockResolvedValue([]);
+
+    await expect(assertHasJobCreditOrThrow("user-no-ent"))
+      .rejects.toBeInstanceOf(NoEntitlementError);
+  });
+
+  it("throws InsufficientJobCreditsError when active but zero credits", async () => {
+    const now = new Date();
+    mockPrisma.userEntitlement.findMany.mockResolvedValue([
+      {
+        id: "ent1",
+        expiresAt: new Date(now.getTime() + 1000),
+        remainingCredits: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+
+    await expect(assertHasJobCreditOrThrow("user-zero"))
+      .rejects.toBeInstanceOf(InsufficientJobCreditsError);
+  });
+
+  it("throws ExpiredJobCreditsError when only expired entitlements exist", async () => {
+    const now = new Date();
+    mockPrisma.userEntitlement.findMany.mockResolvedValue([
+      {
+        id: "ent1",
+        expiresAt: new Date(now.getTime() - 1000),
+        remainingCredits: 2,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+
+    await expect(assertHasJobCreditOrThrow("user-expired"))
+      .rejects.toBeInstanceOf(ExpiredJobCreditsError);
+  });
+});
+
+describe("consumeJobCreditTx", () => {
+  it("decrements exactly once within a transaction", async () => {
+    const now = new Date();
+    const records: MutableEntitlement[] = [
+      {
+        id: "ent1",
+        userId: "user-tx",
+        key: EntitlementKey.JOB_POST_CREDIT,
+        remainingCredits: 2,
+        expiresAt: new Date(now.getTime() + 1000),
+        createdAt: now,
+        updatedAt: now,
+      },
+    ];
+
+    const tx = createTransaction(records);
+
+    await consumeJobCreditTx("user-tx", tx);
+
+    expect(records[0].remainingCredits).toBe(1);
+  });
+
+  it("throws when no active credit exists", async () => {
+    const now = new Date();
+    const records: MutableEntitlement[] = [
+      {
+        id: "ent1",
+        userId: "user-none-active",
+        key: EntitlementKey.JOB_POST_CREDIT,
+        remainingCredits: 0,
+        expiresAt: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ];
+
+    const tx = createTransaction(records);
+
+    await expect(consumeJobCreditTx("user-none-active", tx))
+      .rejects.toBeInstanceOf(InsufficientJobCreditsError);
+  });
+
+  it("is safe under concurrency", async () => {
+    const now = new Date();
+    const records: MutableEntitlement[] = [
+      {
+        id: "ent1",
+        userId: "user-concurrent",
+        key: EntitlementKey.JOB_POST_CREDIT,
+        remainingCredits: 1,
+        expiresAt: new Date(now.getTime() + 1000),
+        createdAt: now,
+        updatedAt: now,
+      },
+    ];
+
+    const barrier = createBarrier(2);
+    const tx = createTransaction(records, { barrier });
+
+    const [first, second] = await Promise.allSettled([
+      consumeJobCreditTx("user-concurrent", tx),
+      consumeJobCreditTx("user-concurrent", tx),
+    ]);
+
+    expect(first.status).toBe("fulfilled");
+    expect(second.status).toBe("rejected");
+    if (second.status === "rejected") {
+      expect(second.reason).toBeInstanceOf(TransientConcurrencyError);
+    }
+    expect(records[0].remainingCredits).toBe(0);
+  });
+});

--- a/apps/web/lib/entitlements/jobs.ts
+++ b/apps/web/lib/entitlements/jobs.ts
@@ -1,0 +1,271 @@
+import type { Prisma } from "@prisma/client";
+import { EntitlementKey } from "@prisma/client";
+
+import {
+  ExpiredJobCreditsError,
+  InsufficientJobCreditsError,
+  NoEntitlementError,
+  TransientConcurrencyError,
+} from "@/lib/errors";
+import { prisma } from "@/lib/prisma";
+
+const JOB_POST_ENTITLEMENT_KEY = EntitlementKey.JOB_POST_CREDIT;
+
+const activeWindowCondition = (now: Date) => [
+  { expiresAt: null },
+  { expiresAt: { gt: now } },
+];
+
+const entitlementSelect = {
+  id: true,
+  expiresAt: true,
+  remainingCredits: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.UserEntitlementSelect;
+
+type JobEntitlementRecord = Prisma.UserEntitlementGetPayload<{
+  select: typeof entitlementSelect;
+}>;
+
+type EntitlementClient = {
+  userEntitlement: {
+    findMany(
+      args: Prisma.UserEntitlementFindManyArgs,
+    ): Promise<JobEntitlementRecord[]> | Prisma.PrismaPromise<JobEntitlementRecord[]>;
+  };
+};
+
+function isWithinActiveWindow(entitlement: JobEntitlementRecord, now: Date) {
+  return entitlement.expiresAt === null || entitlement.expiresAt > now;
+}
+
+function hasRemainingCredits(entitlement: JobEntitlementRecord) {
+  return (entitlement.remainingCredits ?? 0) > 0;
+}
+
+/**
+ * Sort entitlements so we always consume the bundle that expires the soonest.
+ * Null expirations (no expiry) are treated as the most permissive option and
+ * evaluated last. Ties are broken deterministically via updatedAt.
+ */
+function sortForConsumption(
+  entitlements: JobEntitlementRecord[],
+): JobEntitlementRecord[] {
+  return [...entitlements].sort((a, b) => {
+    const aExpires = a.expiresAt;
+    const bExpires = b.expiresAt;
+
+    if (aExpires === null && bExpires === null) {
+      return a.updatedAt.getTime() - b.updatedAt.getTime();
+    }
+
+    if (aExpires === null) {
+      return 1;
+    }
+
+    if (bExpires === null) {
+      return -1;
+    }
+
+    const diff = aExpires.getTime() - bExpires.getTime();
+
+    if (diff !== 0) {
+      return diff;
+    }
+
+    return a.updatedAt.getTime() - b.updatedAt.getTime();
+  });
+}
+
+async function fetchJobEntitlements(
+  client: EntitlementClient,
+  userId: string,
+): Promise<JobEntitlementRecord[]> {
+  return client.userEntitlement.findMany({
+    where: {
+      userId,
+      key: JOB_POST_ENTITLEMENT_KEY,
+    },
+    select: entitlementSelect,
+  });
+}
+
+function evaluateEntitlements(
+  entitlements: JobEntitlementRecord[],
+  now: Date,
+) {
+  const withinWindow = entitlements.filter((entitlement) =>
+    isWithinActiveWindow(entitlement, now),
+  );
+  const withCredits = withinWindow.filter((entitlement) =>
+    hasRemainingCredits(entitlement),
+  );
+  const expired = entitlements.filter(
+    (entitlement) => entitlement.expiresAt && entitlement.expiresAt <= now,
+  );
+
+  return { withinWindow, withCredits, expired };
+}
+
+export async function hasJobCredit(userId: string): Promise<boolean> {
+  const now = new Date();
+  const entitlement = await prisma.userEntitlement.findFirst({
+    where: {
+      userId,
+      key: JOB_POST_ENTITLEMENT_KEY,
+      remainingCredits: { gt: 0 },
+      OR: activeWindowCondition(now),
+    },
+    select: { id: true },
+  });
+
+  return entitlement !== null;
+}
+
+export async function getJobCreditSummary(
+  userId: string,
+): Promise<{ total: number; remaining: number; expiresAt: Date | null } | null> {
+  const now = new Date();
+  const entitlements = await fetchJobEntitlements(prisma, userId);
+  const { withinWindow } = evaluateEntitlements(entitlements, now);
+
+  if (withinWindow.length === 0) {
+    return null;
+  }
+
+  // Remaining credits are the only tracked value today, so total mirrors remaining.
+  const total = withinWindow.reduce(
+    (sum, entitlement) => sum + (entitlement.remainingCredits ?? 0),
+    0,
+  );
+
+  const expiresAt = determineSummaryExpiry(withinWindow);
+
+  return {
+    total,
+    remaining: total,
+    expiresAt,
+  };
+}
+
+function determineSummaryExpiry(
+  entitlements: JobEntitlementRecord[],
+): Date | null {
+  if (entitlements.some((entitlement) => entitlement.expiresAt === null)) {
+    return null;
+  }
+
+  const sorted = sortForConsumption(entitlements);
+  return sorted[0]?.expiresAt ?? null;
+}
+
+export async function assertHasJobCreditOrThrow(userId: string): Promise<void> {
+  const now = new Date();
+  const entitlements = await fetchJobEntitlements(prisma, userId);
+
+  if (entitlements.length === 0) {
+    throw new NoEntitlementError();
+  }
+
+  const { withinWindow, withCredits, expired } = evaluateEntitlements(
+    entitlements,
+    now,
+  );
+
+  if (withCredits.length > 0) {
+    return;
+  }
+
+  if (withinWindow.length > 0) {
+    throw new InsufficientJobCreditsError();
+  }
+
+  if (expired.length > 0) {
+    throw new ExpiredJobCreditsError();
+  }
+
+  throw new NoEntitlementError();
+}
+
+export async function consumeJobCreditTx(
+  userId: string,
+  tx: Prisma.TransactionClient,
+): Promise<void> {
+  const now = new Date();
+  const entitlements = await fetchJobEntitlements(tx, userId);
+
+  if (entitlements.length === 0) {
+    console.debug("[entitlements.jobs] no_entitlement", { userId });
+    throw new NoEntitlementError();
+  }
+
+  const { withinWindow, withCredits, expired } = evaluateEntitlements(
+    entitlements,
+    now,
+  );
+
+  if (withCredits.length === 0) {
+    const reason: "insufficient" | "expired" | "missing" = withinWindow.length
+      ? "insufficient"
+      : expired.length
+        ? "expired"
+        : "missing";
+
+    console.debug("[entitlements.jobs] no_active_credit", {
+      userId,
+      reason,
+    });
+
+    if (reason === "insufficient") {
+      throw new InsufficientJobCreditsError();
+    }
+
+    if (reason === "expired") {
+      throw new ExpiredJobCreditsError();
+    }
+
+    throw new NoEntitlementError();
+  }
+
+  const [target] = sortForConsumption(withCredits);
+  const updateResult = await tx.userEntitlement.updateMany({
+    where: {
+      id: target.id,
+      userId,
+      key: JOB_POST_ENTITLEMENT_KEY,
+      remainingCredits: { gt: 0 },
+      OR: activeWindowCondition(now),
+    },
+    data: {
+      remainingCredits: { decrement: 1 },
+    },
+  });
+
+  if (updateResult.count === 0) {
+    console.debug("[entitlements.jobs] concurrency_conflict", {
+      userId,
+      entitlementId: target.id,
+    });
+
+    throw new TransientConcurrencyError();
+  }
+
+  const remainingAfterConsumption = Math.max(
+    (target.remainingCredits ?? 0) - 1,
+    0,
+  );
+
+  console.debug("[entitlements.jobs] credit_consumed", {
+    userId,
+    entitlementId: target.id,
+    remaining: remainingAfterConsumption,
+  });
+}
+
+export function onJobCreditConsumed(
+  _userId: string,
+  _jobId: string,
+): void {
+  // Placeholder for future notification or analytics hooks.
+}

--- a/apps/web/lib/errors.ts
+++ b/apps/web/lib/errors.ts
@@ -1,0 +1,39 @@
+export class InsufficientJobCreditsError extends Error {
+  readonly code = "INSUFFICIENT_JOB_CREDITS" as const;
+
+  constructor(message = "Insufficient job credits available") {
+    super(message);
+    this.name = "InsufficientJobCreditsError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class ExpiredJobCreditsError extends Error {
+  readonly code = "EXPIRED_JOB_CREDITS" as const;
+
+  constructor(message = "Job credits have expired") {
+    super(message);
+    this.name = "ExpiredJobCreditsError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class NoEntitlementError extends Error {
+  readonly code = "NO_JOB_POST_ENTITLEMENT" as const;
+
+  constructor(message = "No job post entitlement found") {
+    super(message);
+    this.name = "NoEntitlementError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class TransientConcurrencyError extends Error {
+  readonly code = "JOB_CREDIT_CONCURRENCY" as const;
+
+  constructor(message = "Concurrent job credit consumption detected") {
+    super(message);
+    this.name = "TransientConcurrencyError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/apps/web/lib/index.ts
+++ b/apps/web/lib/index.ts
@@ -4,3 +4,5 @@ export { formatRials } from "./money";
 export * from "./env";
 export * from "./http";
 export * from "./url";
+export * from "./errors";
+export * from "./entitlements";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --project tsconfig.json --noEmit",
+    "test": "vitest",
     "prisma": "prisma",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name sprint1_billing_entitlements",
@@ -56,7 +57,8 @@
     "tailwindcss": "^3.4.4",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^2.1.4"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["lib/**/*.test.{ts,tsx}", "**/*.test.{ts,tsx}"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add reusable job entitlement helpers for checking and consuming job posting credits
- introduce typed job credit errors, re-export entitlements, and stub a consumption hook
- configure vitest and add unit tests covering job credit logic

## Testing
- pnpm --filter @app/web test *(fails: network error while fetching pnpm 9.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e3daa90e4c83278411cb5a4e557300