### PR TITLE
Fix typings in entitlement tests to satisfy lint rules

### DIFF
--- a/apps/web/lib/entitlements/jobs.ts
+++ b/apps/web/lib/entitlements/jobs.ts
@@ -267,5 +267,7 @@ export function onJobCreditConsumed(
   _userId: string,
   _jobId: string,
 ): void {
+  void _userId;
+  void _jobId;
   // Placeholder for future notification or analytics hooks.
 }


### PR DESCRIPTION
## Summary
- replace loose any-typed helpers in the job entitlement tests with Prisma-aware typings
- adjust the test transaction mock to return Prisma-shaped payloads without relying on any
- mark the placeholder job credit hook parameters as intentionally unused

## Testing
- pnpm -F @app/web build *(fails: registry download blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e045edc4832787e38ff32b7cadd1