### PR TITLE
feat(web): add public job listing and detail pages

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,0 +1,155 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getCities } from "@/lib/location/cities";
+import { getPublicJobById } from "@/lib/jobs/publicQueries";
+import { buildJobDetailMetadata, buildJobPostingJsonLd, getJobOrganizationName } from "@/lib/jobs/seo";
+import { incrementJobViews } from "@/lib/jobs/views";
+import { buildAbsoluteUrl } from "@/lib/url";
+
+function formatCurrency(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat("fa-IR", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch (error) {
+    const fallback = new Intl.NumberFormat("fa-IR", { maximumFractionDigits: 0 }).format(amount);
+    return `${fallback} ${currency}`;
+  }
+}
+
+function formatPayDetails(job: Awaited<ReturnType<typeof getPublicJobById>>): string | null {
+  if (!job) {
+    return null;
+  }
+
+  const parts: string[] = [];
+
+  if (job.payType) {
+    parts.push(job.payType);
+  }
+
+  if (job.payAmount !== null && job.payAmount !== undefined && job.currency) {
+    parts.push(formatCurrency(job.payAmount, job.currency));
+  }
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return parts.join(" | ");
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { id: string };
+}): Promise<Metadata> {
+  const job = await getPublicJobById(params.id);
+
+  if (!job) {
+    return {
+      title: "آگهی یافت نشد",
+    };
+  }
+
+  const cities = await getCities();
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+  const cityName = job.cityId ? cityMap.get(job.cityId) : undefined;
+
+  return buildJobDetailMetadata(job, { cityName });
+}
+
+export default async function JobDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const job = await getPublicJobById(params.id);
+
+  if (!job) {
+    notFound();
+  }
+
+  if (job.status !== "PUBLISHED" || job.moderation !== "APPROVED") {
+    notFound();
+  }
+
+  const [cities] = await Promise.all([getCities()]);
+
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+  const cityName = job.cityId ? cityMap.get(job.cityId) ?? job.cityId : undefined;
+
+  incrementJobViews(job.id).catch(() => {});
+
+  const organizationName = getJobOrganizationName(job);
+  const payDetails = formatPayDetails(job);
+  const isFeatured = job.featuredUntil ? job.featuredUntil > new Date() : false;
+  const jsonLd = buildJobPostingJsonLd(job, {
+    cityName,
+    url: buildAbsoluteUrl(`/jobs/${job.id}`),
+  });
+  const postedAt = new Intl.DateTimeFormat("fa-IR", {
+    dateStyle: "medium",
+  }).format(job.createdAt);
+
+  const profileLink = job.user.profile ? `/profiles/${job.user.profile.id}` : null;
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 px-6 pb-12" dir="rtl">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <Card className="border border-border shadow-sm">
+        <CardHeader className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="space-y-2">
+              <CardTitle className="text-2xl font-bold text-foreground">{job.title}</CardTitle>
+              <CardDescription className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+                <span>دسته‌بندی: {job.category}</span>
+                {cityName ? <span>شهر: {cityName}</span> : null}
+                <span>تاریخ انتشار: {postedAt}</span>
+              </CardDescription>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {isFeatured ? <Badge variant="warning">ویژه</Badge> : null}
+              {job.remote ? <Badge variant="outline">دورکاری</Badge> : null}
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+            <span>کارفرما: {organizationName}</span>
+            {payDetails ? <span>شرایط پرداخت: {payDetails}</span> : null}
+            {profileLink ? (
+              <Link href={profileLink} className="text-primary underline">
+                مشاهده پروفایل کارفرما
+              </Link>
+            ) : null}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <h2 className="text-lg font-semibold text-foreground">توضیحات آگهی</h2>
+          <p className="whitespace-pre-line text-sm leading-7 text-muted-foreground">{job.description}</p>
+        </CardContent>
+      </Card>
+
+      <Card className="border border-border shadow-sm">
+        <CardHeader>
+          <CardTitle>درخواست همکاری</CardTitle>
+          <CardDescription>
+            سامانه درخواست آنلاین به زودی فعال می‌شود. در حال حاضر می‌توانید با کارفرما به صورت مستقیم هماهنگ کنید.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button className="w-full" disabled>
+            ارسال درخواست (به زودی)
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/jobs/loading.tsx
+++ b/apps/web/app/jobs/loading.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const CARD_COUNT = 6;
+
+export default function JobsLoading() {
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 pb-12" dir="rtl">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: CARD_COUNT }).map((_, index) => (
+          <div key={index} className="space-y-3 rounded-md border border-border bg-background p-4 shadow-sm">
+            <Skeleton className="h-6 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-4 w-full" />
+            <div className="flex gap-2">
+              <Skeleton className="h-6 w-16" />
+              <Skeleton className="h-6 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/jobs/not-found.tsx
+++ b/apps/web/app/jobs/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function JobNotFound() {
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col items-center justify-center gap-4 px-6 py-24 text-center" dir="rtl">
+      <h1 className="text-3xl font-bold text-foreground">آگهی مورد نظر پیدا نشد</h1>
+      <p className="text-sm text-muted-foreground">
+        ممکن است این فرصت شغلی حذف شده باشد یا هنوز برای نمایش عمومی تایید نشده باشد.
+      </p>
+      <Link
+        href="/jobs"
+        className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+      >
+        بازگشت به لیست فرصت‌های شغلی
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/app/jobs/page.tsx
+++ b/apps/web/app/jobs/page.tsx
@@ -1,0 +1,407 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { getCities } from "@/lib/location/cities";
+import {
+  getPublicJobFilters,
+  getPublicJobs,
+  type PublicJobQueryParams,
+  type PublicJobSort,
+} from "@/lib/jobs/publicQueries";
+import {
+  buildJobListingMetadata,
+  buildJobPostingGraphJsonLd,
+  getJobDescriptionSnippet,
+  getJobOrganizationName,
+} from "@/lib/jobs/seo";
+import type { PublicJobWithOwner } from "@/lib/jobs/publicQueries";
+
+const SORT_OPTIONS: { value: PublicJobSort; label: string }[] = [
+  { value: "newest", label: "جدیدترین" },
+  { value: "featured", label: "ویژه‌ها" },
+  { value: "expiring", label: "رو به پایان" },
+];
+
+type RawSearchParams = Record<string, string | string[] | undefined>;
+
+type NormalizedParams = PublicJobQueryParams & {
+  sort?: PublicJobSort;
+};
+
+function getSingleParam(value: string | string[] | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value[0]?.trim() || undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function parseSort(value: string | undefined): PublicJobSort | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (SORT_OPTIONS.some((option) => option.value === value)) {
+    return value as PublicJobSort;
+  }
+
+  return undefined;
+}
+
+function parseRemote(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+function parsePage(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function normalizeSearchParams(searchParams: RawSearchParams): NormalizedParams {
+  const city = getSingleParam(searchParams.city);
+  const category = getSingleParam(searchParams.category);
+  const payType = getSingleParam(searchParams.payType);
+  const sort = parseSort(getSingleParam(searchParams.sort));
+  const page = parsePage(getSingleParam(searchParams.page));
+  const remote = parseRemote(getSingleParam(searchParams.remote));
+
+  return {
+    city,
+    category,
+    payType,
+    sort,
+    page,
+    remote,
+  };
+}
+
+function resolveCityNameFactory(cityMap: Map<string, string>) {
+  return (cityId: string | null): string | undefined => {
+    if (!cityId) {
+      return undefined;
+    }
+
+    return cityMap.get(cityId) ?? undefined;
+  };
+}
+
+function formatPaySnippet(job: PublicJobWithOwner): string | null {
+  if (job.payAmount !== null && job.payAmount !== undefined && job.currency) {
+    try {
+      const formatter = new Intl.NumberFormat("fa-IR", {
+        style: "currency",
+        currency: job.currency,
+        maximumFractionDigits: 0,
+      });
+
+      return formatter.format(job.payAmount);
+    } catch (error) {
+      const fallback = new Intl.NumberFormat("fa-IR", {
+        maximumFractionDigits: 0,
+      }).format(job.payAmount);
+      return `${fallback} ${job.currency}`;
+    }
+  }
+
+  if (job.payType) {
+    return `نوع پرداخت: ${job.payType}`;
+  }
+
+  return null;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: RawSearchParams;
+}): Promise<Metadata> {
+  const normalized = normalizeSearchParams(searchParams);
+  const cities = await getCities();
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+  const cityName = normalized.city ? cityMap.get(normalized.city) : undefined;
+
+  return buildJobListingMetadata({
+    cityName,
+    category: normalized.category,
+    remote: normalized.remote,
+    payType: normalized.payType,
+    page: normalized.page,
+  });
+}
+
+export default async function JobsPage({
+  searchParams,
+}: {
+  searchParams: RawSearchParams;
+}) {
+  const normalized = normalizeSearchParams(searchParams);
+
+  const [cities, filters, jobsResult] = await Promise.all([
+    getCities(),
+    getPublicJobFilters(),
+    getPublicJobs(normalized),
+  ]);
+
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+  const resolveCityName = resolveCityNameFactory(cityMap);
+
+  const persistedParams = new URLSearchParams();
+
+  if (normalized.city) {
+    persistedParams.set("city", normalized.city);
+  }
+
+  if (normalized.category) {
+    persistedParams.set("category", normalized.category);
+  }
+
+  if (normalized.payType) {
+    persistedParams.set("payType", normalized.payType);
+  }
+
+  if (normalized.sort) {
+    persistedParams.set("sort", normalized.sort);
+  }
+
+  if (normalized.remote) {
+    persistedParams.set("remote", "1");
+  }
+
+  const buildPageHref = (page: number) => {
+    const params = new URLSearchParams(persistedParams);
+    if (page > 1) {
+      params.set("page", String(page));
+    } else {
+      params.delete("page");
+    }
+
+    const query = params.toString();
+    return query ? `/jobs?${query}` : "/jobs";
+  };
+
+  const jsonLd =
+    jobsResult.items.length > 0
+      ? buildJobPostingGraphJsonLd(jobsResult.items, resolveCityName)
+      : null;
+
+  const now = new Date();
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 pb-12" dir="rtl">
+      {jsonLd ? (
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>فرصت‌های شغلی</CardTitle>
+          <CardDescription>
+            جستجو و فیلتر فرصت‌های تایید شده برای بازیگران و هنرمندان.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-4 md:grid-cols-2 lg:grid-cols-3" method="get">
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium" htmlFor="city">
+                شهر
+              </label>
+              <select
+                id="city"
+                name="city"
+                defaultValue={normalized.city ?? ""}
+                className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+              >
+                <option value="">همه شهرها</option>
+                {cities.map((city) => (
+                  <option key={city.id} value={city.id}>
+                    {city.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium" htmlFor="category">
+                دسته‌بندی
+              </label>
+              <select
+                id="category"
+                name="category"
+                defaultValue={normalized.category ?? ""}
+                className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+              >
+                <option value="">همه دسته‌ها</option>
+                {filters.categories.map((category) => (
+                  <option key={category} value={category}>
+                    {category}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium" htmlFor="payType">
+                نوع پرداخت
+              </label>
+              <select
+                id="payType"
+                name="payType"
+                defaultValue={normalized.payType ?? ""}
+                className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+              >
+                <option value="">همه گزینه‌ها</option>
+                {filters.payTypes.map((payType) => (
+                  <option key={payType} value={payType}>
+                    {payType}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium">امکان دورکاری</span>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  name="remote"
+                  value="1"
+                  defaultChecked={normalized.remote}
+                  className="h-4 w-4 rounded border border-input"
+                />
+                فقط آگهی‌های دورکاری
+              </label>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium" htmlFor="sort">
+                مرتب‌سازی
+              </label>
+              <select
+                id="sort"
+                name="sort"
+                defaultValue={normalized.sort ?? "newest"}
+                className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+              >
+                {SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="md:col-span-2 lg:col-span-3">
+              <Button type="submit" className="w-full">
+                اعمال فیلترها
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {jobsResult.items.length === 0 ? (
+        <div className="rounded-md border border-dashed border-border bg-background p-8 text-center text-sm text-muted-foreground">
+          هیچ فرصت شغلی با فیلترهای فعلی یافت نشد.
+          <div className="mt-4">
+            <Link href="/jobs" className="text-primary underline">
+              حذف فیلترها و مشاهده همه آگهی‌ها
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {jobsResult.items.map((job) => {
+            const cityName = resolveCityName(job.cityId ?? null);
+            const isFeatured = job.featuredUntil ? job.featuredUntil > now : false;
+            const paySnippet = formatPaySnippet(job);
+            const snippet = getJobDescriptionSnippet(job, 150);
+            const organizationName = getJobOrganizationName(job);
+
+            return (
+              <Card key={job.id} className="flex h-full flex-col border border-border shadow-sm">
+                <CardHeader className="space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <CardTitle className="line-clamp-2 text-lg font-semibold text-foreground">
+                      {job.title}
+                    </CardTitle>
+                    <div className="flex items-center gap-2">
+                      {isFeatured ? <Badge variant="warning">ویژه</Badge> : null}
+                      {job.remote ? <Badge variant="outline">دورکاری</Badge> : null}
+                    </div>
+                  </div>
+                  <CardDescription className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                    <span>دسته‌بندی: {job.category}</span>
+                    {cityName ? <span>شهر: {cityName}</span> : null}
+                    <span>کارفرما: {organizationName}</span>
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex-1 space-y-3">
+                  <p className="line-clamp-3 text-sm leading-6 text-muted-foreground">{snippet}</p>
+                  {paySnippet ? (
+                    <div className="flex flex-wrap gap-2">
+                      <Badge variant="secondary">{paySnippet}</Badge>
+                    </div>
+                  ) : null}
+                </CardContent>
+                <CardFooter className="flex justify-end">
+                  <Button asChild variant="outline">
+                    <Link href={`/jobs/${job.id}`}>مشاهده جزئیات</Link>
+                  </Button>
+                </CardFooter>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {jobsResult.items.length > 0 ? (
+        <div className="flex items-center justify-between rounded-md border border-border bg-background px-4 py-3 text-sm">
+          <span>
+            صفحه {jobsResult.page} از {jobsResult.totalPages}
+          </span>
+          <div className="flex items-center gap-2">
+            {jobsResult.page > 1 ? (
+              <Button asChild variant="outline">
+                <Link href={buildPageHref(jobsResult.page - 1)}>صفحه قبل</Link>
+              </Button>
+            ) : (
+              <Button variant="outline" disabled>
+                صفحه قبل
+              </Button>
+            )}
+            {jobsResult.page < jobsResult.totalPages ? (
+              <Button asChild variant="outline">
+                <Link href={buildPageHref(jobsResult.page + 1)}>صفحه بعد</Link>
+              </Button>
+            ) : (
+              <Button variant="outline" disabled>
+                صفحه بعد
+              </Button>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/jobs/publicQueries.ts
+++ b/apps/web/lib/jobs/publicQueries.ts
@@ -1,0 +1,191 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+export const PUBLIC_JOBS_PAGE_SIZE = 12;
+
+export type PublicJobSort = "newest" | "featured" | "expiring";
+
+export type PublicJobQueryParams = {
+  city?: string;
+  category?: string;
+  remote?: boolean;
+  payType?: string;
+  sort?: PublicJobSort;
+  page?: number;
+};
+
+export type PublicJobWithOwner = Prisma.JobGetPayload<{
+  include: {
+    user: {
+      select: {
+        id: true;
+        name: true;
+        profile: {
+          select: {
+            id: true;
+            stageName: true;
+            firstName: true;
+            lastName: true;
+          };
+        };
+      };
+    };
+  };
+}>;
+
+const BASE_VISIBILITY_WHERE: Prisma.JobWhereInput = {
+  status: "PUBLISHED",
+  moderation: "APPROVED",
+};
+
+export function buildPublicWhere(
+  params: Pick<PublicJobQueryParams, "city" | "category" | "remote" | "payType">
+): Prisma.JobWhereInput {
+  const where: Prisma.JobWhereInput = {
+    ...BASE_VISIBILITY_WHERE,
+  };
+
+  if (params.city) {
+    where.cityId = params.city;
+  }
+
+  if (params.category) {
+    where.category = params.category;
+  }
+
+  if (params.remote) {
+    where.remote = true;
+  }
+
+  if (params.payType) {
+    where.payType = params.payType;
+  }
+
+  return where;
+}
+
+export function buildPublicOrderBy(
+  sort: PublicJobSort | undefined
+): Prisma.JobOrderByWithRelationInput[] {
+  switch (sort) {
+    case "featured":
+      return [
+        { featuredUntil: { sort: "desc", nulls: "last" } },
+        { createdAt: "desc" },
+      ];
+    case "expiring":
+      return [
+        { featuredUntil: { sort: "asc", nulls: "last" } },
+        { createdAt: "desc" },
+      ];
+    case "newest":
+    default:
+      return [{ createdAt: "desc" }];
+  }
+}
+
+export async function getPublicJobs(params: PublicJobQueryParams = {}) {
+  const page = Math.max(params.page ?? 1, 1);
+  const skip = (page - 1) * PUBLIC_JOBS_PAGE_SIZE;
+
+  const where = buildPublicWhere({
+    city: params.city,
+    category: params.category,
+    remote: params.remote,
+    payType: params.payType,
+  });
+
+  const orderBy = buildPublicOrderBy(params.sort);
+
+  const [items, total] = await Promise.all([
+    prisma.job.findMany({
+      where,
+      orderBy,
+      skip,
+      take: PUBLIC_JOBS_PAGE_SIZE,
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            profile: {
+              select: {
+                id: true,
+                stageName: true,
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.job.count({ where }),
+  ]);
+
+  return {
+    items,
+    total,
+    page,
+    pageSize: PUBLIC_JOBS_PAGE_SIZE,
+    totalPages: Math.max(1, Math.ceil(total / PUBLIC_JOBS_PAGE_SIZE)),
+  };
+}
+
+export async function getPublicJobById(id: string) {
+  if (!id) {
+    return null;
+  }
+
+  return prisma.job.findFirst({
+    where: {
+      ...BASE_VISIBILITY_WHERE,
+      id,
+    },
+    include: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          profile: {
+            select: {
+              id: true,
+              stageName: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+export async function getPublicJobFilters() {
+  const where = { ...BASE_VISIBILITY_WHERE } satisfies Prisma.JobWhereInput;
+
+  const [categories, payTypes] = await Promise.all([
+    prisma.job.findMany({
+      where,
+      distinct: ["category"],
+      orderBy: { category: "asc" },
+      select: { category: true },
+    }),
+    prisma.job.findMany({
+      where: {
+        ...where,
+        payType: { not: null },
+      },
+      distinct: ["payType"],
+      orderBy: { payType: "asc" },
+      select: { payType: true },
+    }),
+  ]);
+
+  return {
+    categories: categories.map((entry) => entry.category).filter(Boolean),
+    payTypes: payTypes
+      .map((entry) => entry.payType)
+      .filter((value): value is string => Boolean(value && value.trim())),
+  };
+}

--- a/apps/web/lib/jobs/seo.ts
+++ b/apps/web/lib/jobs/seo.ts
@@ -1,0 +1,229 @@
+import type { Metadata } from "next";
+
+import { buildAbsoluteUrl } from "@/lib/url";
+
+import type { PublicJobWithOwner } from "./publicQueries";
+
+const EMPLOYMENT_TYPE_MAP: Record<string, string> = {
+  full_time: "FULL_TIME",
+  part_time: "PART_TIME",
+  contract: "CONTRACTOR",
+  contractor: "CONTRACTOR",
+  freelance: "CONTRACTOR",
+  temporary: "TEMPORARY",
+  internship: "INTERN",
+  intern: "INTERN",
+  seasonal: "TEMPORARY",
+  volunteer: "VOLUNTEER",
+};
+
+function stripHtml(value: string): string {
+  return value.replace(/<[^>]*>/g, "");
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function sanitizeDescription(value: string): string {
+  return collapseWhitespace(stripHtml(value));
+}
+
+function mapEmploymentType(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const key = value.trim().toLowerCase();
+  return EMPLOYMENT_TYPE_MAP[key];
+}
+
+export function getJobOrganizationName(job: PublicJobWithOwner): string {
+  const profile = job.user?.profile ?? null;
+
+  if (profile?.stageName?.trim()) {
+    return profile.stageName.trim();
+  }
+
+  const fullName = `${profile?.firstName ?? ""} ${profile?.lastName ?? ""}`.trim();
+  if (fullName) {
+    return fullName;
+  }
+
+  if (job.user?.name?.trim()) {
+    return job.user.name.trim();
+  }
+
+  return "کارفرما";
+}
+
+type JobPostingJsonLdOptions = {
+  cityName?: string;
+  url?: string;
+  includeContext?: boolean;
+};
+
+export function buildJobPostingJsonLd(
+  job: PublicJobWithOwner,
+  options: JobPostingJsonLdOptions = {}
+): Record<string, unknown> {
+  const description = sanitizeDescription(job.description);
+  const employmentType = mapEmploymentType(job.payType);
+  const organizationName = getJobOrganizationName(job);
+
+  const base: Record<string, unknown> = {
+    ...(options.includeContext === false ? {} : { "@context": "https://schema.org" }),
+    "@type": "JobPosting",
+    title: job.title,
+    description,
+    datePosted: job.createdAt.toISOString(),
+    hiringOrganization: {
+      "@type": "Organization",
+      name: organizationName,
+    },
+    ...(options.url ? { url: options.url } : {}),
+    identifier: {
+      "@type": "PropertyValue",
+      name: "internal",
+      value: job.id,
+    },
+    ...(employmentType ? { employmentType } : {}),
+    ...(job.remote ? { jobLocationType: "TELECOMMUTE" } : {}),
+  };
+
+  if (options.cityName) {
+    base.jobLocation = {
+      "@type": "Place",
+      address: {
+        "@type": "PostalAddress",
+        addressLocality: options.cityName,
+        addressCountry: "IR",
+      },
+    };
+  }
+
+  if (job.payAmount !== null && job.payAmount !== undefined && job.currency) {
+    base.baseSalary = {
+      "@type": "MonetaryAmount",
+      currency: job.currency,
+      value: {
+        "@type": "QuantitativeValue",
+        value: job.payAmount,
+      },
+    };
+  }
+
+  return base;
+}
+
+export function buildJobPostingGraphJsonLd(
+  jobs: PublicJobWithOwner[],
+  resolveCityName: (cityId: string | null) => string | undefined
+): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@graph": jobs.map((job) =>
+      buildJobPostingJsonLd(job, {
+        includeContext: false,
+        cityName: resolveCityName(job.cityId ?? null),
+        url: buildAbsoluteUrl(`/jobs/${job.id}`),
+      })
+    ),
+  };
+}
+
+export function getJobDescriptionSnippet(job: PublicJobWithOwner, length = 160): string {
+  const sanitized = sanitizeDescription(job.description);
+  if (sanitized.length <= length) {
+    return sanitized;
+  }
+  return `${sanitized.slice(0, length - 1)}…`;
+}
+
+type ListingMetadataOptions = {
+  cityName?: string;
+  category?: string;
+  remote?: boolean;
+  payType?: string;
+  page?: number;
+};
+
+export function buildJobListingMetadata(options: ListingMetadataOptions = {}): Metadata {
+  const titleParts = ["فرصت‌های شغلی"];
+
+  if (options.category) {
+    titleParts.push(`دسته ${options.category}`);
+  }
+
+  if (options.cityName) {
+    titleParts.push(`در ${options.cityName}`);
+  }
+
+  if (options.remote) {
+    titleParts.push("دورکاری");
+  }
+
+  const title = titleParts.join(" | ");
+
+  const descriptionParts = [
+    "آخرین فرصت‌های شغلی تاییدشده برای هنرمندان و بازیگران.",
+  ];
+
+  const filterDescriptions: string[] = [];
+
+  if (options.category) {
+    filterDescriptions.push(`دسته‌بندی ${options.category}`);
+  }
+
+  if (options.cityName) {
+    filterDescriptions.push(`شهر ${options.cityName}`);
+  }
+
+  if (options.payType) {
+    filterDescriptions.push(`نوع پرداخت ${options.payType}`);
+  }
+
+  if (options.remote) {
+    filterDescriptions.push("فرصت‌های دورکاری");
+  }
+
+  if (filterDescriptions.length) {
+    descriptionParts.push(`فیلتر شده بر اساس ${filterDescriptions.join("، ")}.`);
+  }
+
+  if (options.page && options.page > 1) {
+    descriptionParts.push(`صفحه ${options.page}`);
+  }
+
+  return {
+    title,
+    description: descriptionParts.join(" "),
+  };
+}
+
+type DetailMetadataOptions = {
+  cityName?: string;
+};
+
+export function buildJobDetailMetadata(
+  job: PublicJobWithOwner,
+  options: DetailMetadataOptions = {}
+): Metadata {
+  const organizationName = getJobOrganizationName(job);
+  const snippet = getJobDescriptionSnippet(job, 160);
+
+  const descriptionParts = [snippet];
+
+  if (options.cityName) {
+    descriptionParts.push(`محل کار: ${options.cityName}.`);
+  }
+
+  if (job.remote) {
+    descriptionParts.push("امکان فعالیت به صورت دورکاری فراهم است.");
+  }
+
+  return {
+    title: `${job.title} | ${organizationName}`,
+    description: descriptionParts.join(" "),
+  };
+}

--- a/apps/web/lib/jobs/views.ts
+++ b/apps/web/lib/jobs/views.ts
@@ -1,0 +1,18 @@
+import { prisma } from "@/lib/prisma";
+
+export async function incrementJobViews(jobId: string): Promise<void> {
+  if (!jobId) {
+    return;
+  }
+
+  try {
+    await prisma.job.update({
+      where: { id: jobId },
+      data: { views: { increment: 1 } },
+    });
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("Failed to increment job views", { jobId, error });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add server-rendered /jobs listing with filters, sorting, pagination, and structured data
- implement public job detail page with JSON-LD, featured/remote indicators, and safe view counter increment
- introduce shared public job query helpers, SEO builders, and view tracking utilities

## Testing
- `pnpm --filter web lint` *(fails: registry download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fd3788d08327abd0fd71647a0990