### PR TITLE
Fix Link href types for job pages

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -99,7 +99,9 @@ export default async function JobDetailPage({
     dateStyle: "medium",
   }).format(job.createdAt);
 
-  const profileLink = job.user.profile ? `/profiles/${job.user.profile.id}` : null;
+  const profileLink = job.user.profile
+    ? { pathname: "/profiles/[id]", query: { id: job.user.profile.id } }
+    : null;
 
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-6 px-6 pb-12" dir="rtl">

--- a/apps/web/app/jobs/page.tsx
+++ b/apps/web/app/jobs/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { LinkProps } from "next/link";
 import type { Metadata } from "next";
 
 import { Badge } from "@/components/ui/badge";
@@ -188,7 +189,7 @@ export default async function JobsPage({
     persistedParams.set("remote", "1");
   }
 
-  const buildPageHref = (page: number) => {
+  const buildPageHref = (page: number): LinkProps["href"] => {
     const params = new URLSearchParams(persistedParams);
     if (page > 1) {
       params.set("page", String(page));
@@ -196,8 +197,12 @@ export default async function JobsPage({
       params.delete("page");
     }
 
-    const query = params.toString();
-    return query ? `/jobs?${query}` : "/jobs";
+    const queryEntries = Object.fromEntries(params.entries());
+
+    return {
+      pathname: "/jobs",
+      query: Object.keys(queryEntries).length > 0 ? queryEntries : undefined,
+    };
   };
 
   const jsonLd =


### PR DESCRIPTION
## Summary
- switch job detail employer profile link to use a UrlObject so Next.js accepts the href
- return UrlObject pagination targets for the job listings page and type them with LinkProps

## Testing
- `pnpm -C apps/web typecheck` *(fails: corepack cannot download pnpm@9.0.0 due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_68e400ac43e88327832327f701f84bf0