### PR TITLE
Add admin job moderation dashboard

### DIFF
--- a/apps/web/app/(admin)/admin/jobs/[id]/page.tsx
+++ b/apps/web/app/(admin)/admin/jobs/[id]/page.tsx
@@ -1,0 +1,123 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { closeJobAction } from "@/app/(admin)/admin/jobs/actions";
+import { FeatureControls } from "@/components/admin/jobs/FeatureControls";
+import { ModerationControls } from "@/components/admin/jobs/ModerationControls";
+import { StatusPills } from "@/components/admin/jobs/StatusPills";
+import { Button } from "@/components/ui/button";
+import { getServerAuthSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma";
+
+function formatDate(value: Date): string {
+  return new Intl.DateTimeFormat("fa-IR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(value);
+}
+
+async function getJob(id: string) {
+  return prisma.job.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      status: true,
+      moderation: true,
+      featuredUntil: true,
+      createdAt: true,
+      updatedAt: true,
+      user: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+}
+
+export default async function AdminJobDetailPage({ params }: { params: { id: string } }) {
+  const session = await getServerAuthSession();
+  if (!session?.user || session.user.role !== "ADMIN") {
+    notFound();
+  }
+
+  const job = await getJob(params.id);
+
+  if (!job) {
+    notFound();
+  }
+
+  const featuredLabel = job.featuredUntil ? formatDate(job.featuredUntil) : "ویژه نیست";
+  const createdLabel = formatDate(job.createdAt);
+  const updatedLabel = formatDate(job.updatedAt);
+  const ownerName = job.user.name?.trim()?.length ? job.user.name : "بدون نام";
+
+  async function closeJob() {
+    "use server";
+    await closeJobAction(job.id);
+  }
+
+  return (
+    <div className="space-y-6" dir="rtl">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold">مدیریت آگهی: {job.title}</h1>
+        <p className="text-sm text-muted-foreground">
+          در این صفحه می‌توانید وضعیت آگهی را تغییر دهید و اطلاعات تکمیلی را مشاهده کنید.
+        </p>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <div className="space-y-4 rounded-lg border border-border bg-background p-4 shadow-sm">
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <h2 className="text-lg font-semibold text-foreground">اطلاعات آگهی</h2>
+            <p>شناسه: {job.id}</p>
+            <p>مالک: {ownerName}</p>
+            <p>شناسه مالک: {job.user.id}</p>
+            <p>ساخته شده در: {createdLabel}</p>
+            <p>آخرین بروزرسانی: {updatedLabel}</p>
+            <p>ویژه تا: {featuredLabel}</p>
+          </div>
+
+          <StatusPills
+            status={job.status}
+            moderation={job.moderation}
+            featuredUntil={job.featuredUntil ? job.featuredUntil.toISOString() : null}
+          />
+
+          <div className="flex flex-col gap-4">
+            <ModerationControls jobId={job.id} moderation={job.moderation} />
+            <div className="flex flex-wrap items-center gap-3">
+              <FeatureControls jobId={job.id} featuredUntil={job.featuredUntil?.toISOString() ?? null} />
+              {job.status !== "CLOSED" ? (
+                <form action={closeJob}>
+                  <Button variant="outline" className="text-destructive">
+                    بستن آگهی
+                  </Button>
+                </form>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 text-sm text-primary">
+            <Link href={`/jobs/${job.id}`} className="hover:underline">
+              مشاهده در سایت
+            </Link>
+            <Link href={`/dashboard/jobs/${job.id}/edit`} className="hover:underline">
+              صفحه ویرایش مالک
+            </Link>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-background p-4 shadow-sm">
+          <h2 className="text-lg font-semibold">توضیحات آگهی</h2>
+          <p className="mt-4 whitespace-pre-wrap text-sm leading-7 text-muted-foreground">
+            {job.description}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(admin)/admin/jobs/actions.ts
+++ b/apps/web/app/(admin)/admin/jobs/actions.ts
@@ -1,0 +1,176 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { notFound } from "next/navigation";
+import { z } from "zod";
+
+import { getServerAuthSession } from "@/lib/auth/session";
+import { approveJobAdmin } from "@/lib/jobs/admin/approveJob";
+import { closeJobByAdmin } from "@/lib/jobs/admin/closeJobAdmin";
+import { featureJobAdmin, type FeatureJobCommand } from "@/lib/jobs/admin/featureJob";
+import { InvalidFeatureScheduleError, InvalidModerationTransitionError } from "@/lib/jobs/admin/common";
+import { rejectJobAdmin } from "@/lib/jobs/admin/rejectJob";
+import { suspendJobAdmin } from "@/lib/jobs/admin/suspendJob";
+import { JobNotFoundError } from "@/lib/jobs/errors";
+
+const idSchema = z.string().cuid({ message: "شناسه آگهی معتبر نیست." });
+const noteSchema = z
+  .string({ invalid_type_error: "توضیح وارد شده معتبر نیست." })
+  .trim()
+  .max(500, "حداکثر ۵۰۰ کاراکتر مجاز است.");
+
+const featureCommandSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("PRESET"), days: z.union([z.literal(7), z.literal(14), z.literal(30)]) }),
+  z.object({
+    type: z.literal("CUSTOM"),
+    until: z
+      .string({ invalid_type_error: "تاریخ معتبر نیست." })
+      .refine((value) => {
+        const parsed = new Date(value);
+        return !Number.isNaN(parsed.getTime());
+      }, "تاریخ معتبر نیست.")
+      .transform((value) => new Date(value)),
+  }),
+  z.object({ type: z.literal("CLEAR") }),
+]);
+
+type FeatureCommandInput = z.infer<typeof featureCommandSchema>;
+
+type SimpleActionResult = { ok: true } | { ok: false; error: string };
+
+type AdminUser = { id: string; role: "ADMIN" };
+
+async function ensureAdmin(): Promise<AdminUser> {
+  const session = await getServerAuthSession();
+  const user = session?.user;
+
+  if (!user || user.role !== "ADMIN" || typeof user.id !== "string" || user.id.length === 0) {
+    notFound();
+  }
+
+  return { id: user.id, role: "ADMIN" };
+}
+
+function parseOptionalNote(note?: string): string | undefined {
+  if (note === undefined) {
+    return undefined;
+  }
+  const parsed = noteSchema.parse(note);
+  return parsed.length > 0 ? parsed : undefined;
+}
+
+function parseFeatureCommand(command: FeatureCommandInput): FeatureJobCommand {
+  if (command.type === "CUSTOM") {
+    return { type: "CUSTOM", until: command.until };
+  }
+  if (command.type === "PRESET") {
+    return { type: "PRESET", days: command.days };
+  }
+  return { type: "CLEAR" };
+}
+
+function translateError(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    return error.issues[0]?.message ?? "ورودی ارسال شده معتبر نیست.";
+  }
+
+  if (error instanceof JobNotFoundError) {
+    return "آگهی موردنظر یافت نشد.";
+  }
+
+  if (error instanceof InvalidModerationTransitionError) {
+    return "تغییر وضعیت در حالت فعلی مجاز نیست.";
+  }
+
+  if (error instanceof InvalidFeatureScheduleError) {
+    return error.message;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "خطایی رخ داد. لطفاً دوباره تلاش کنید.";
+}
+
+async function revalidateAdminJobPages(jobId: string) {
+  await revalidatePath("/admin/jobs");
+  await revalidatePath(`/admin/jobs/${jobId}`);
+}
+
+export async function approveJobAction(jobId: string): Promise<SimpleActionResult> {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(jobId);
+
+    await approveJobAdmin(id, admin.id);
+    await revalidateAdminJobPages(id);
+
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: translateError(error) };
+  }
+}
+
+export async function rejectJobAction(jobId: string, note?: string): Promise<SimpleActionResult> {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(jobId);
+    const parsedNote = parseOptionalNote(note);
+
+    await rejectJobAdmin(id, admin.id, parsedNote);
+    await revalidateAdminJobPages(id);
+
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: translateError(error) };
+  }
+}
+
+export async function suspendJobAction(jobId: string, note?: string): Promise<SimpleActionResult> {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(jobId);
+    const parsedNote = parseOptionalNote(note);
+
+    await suspendJobAdmin(id, admin.id, parsedNote);
+    await revalidateAdminJobPages(id);
+
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: translateError(error) };
+  }
+}
+
+export async function featureJobAction(
+  jobId: string,
+  command: FeatureCommandInput,
+): Promise<SimpleActionResult> {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(jobId);
+    const parsed = featureCommandSchema.parse(command);
+    const featureCommand = parseFeatureCommand(parsed);
+
+    await featureJobAdmin(id, admin.id, featureCommand);
+    await revalidateAdminJobPages(id);
+
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: translateError(error) };
+  }
+}
+
+export async function closeJobAction(jobId: string): Promise<SimpleActionResult> {
+  try {
+    const admin = await ensureAdmin();
+    const id = idSchema.parse(jobId);
+
+    await closeJobByAdmin(id, admin.id);
+    await revalidateAdminJobPages(id);
+
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: translateError(error) };
+  }
+}

--- a/apps/web/app/(admin)/admin/jobs/page.tsx
+++ b/apps/web/app/(admin)/admin/jobs/page.tsx
@@ -1,0 +1,297 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import type { JobModeration, JobStatus } from "@prisma/client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { JobsAdminTable, type JobAdminRow } from "@/components/admin/jobs/JobsAdminTable";
+import { getServerAuthSession } from "@/lib/auth/session";
+import { listJobsForAdmin } from "@/lib/jobs/admin/listJobs";
+
+const PAGE_SIZE = 20;
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+type ModerationOption = "pending" | "approved" | "rejected" | "suspended" | "all";
+type StatusOption = "draft" | "published" | "closed" | "all";
+
+type ParsedFilters = {
+  moderation?: JobModeration;
+  status?: JobStatus;
+  featured?: "ONLY" | "NONE";
+  userQuery?: string;
+  search?: string;
+  dateFrom?: Date;
+  dateTo?: Date;
+  featuredRaw?: string | undefined;
+  moderationRaw?: string | undefined;
+  statusRaw?: string | undefined;
+  userRaw?: string | undefined;
+  searchRaw?: string | undefined;
+  dateFromRaw?: string | undefined;
+  dateToRaw?: string | undefined;
+  page: number;
+};
+
+const MODERATION_MAP: Record<ModerationOption, JobModeration | undefined> = {
+  pending: "PENDING",
+  approved: "APPROVED",
+  rejected: "REJECTED",
+  suspended: "SUSPENDED",
+  all: undefined,
+};
+
+const STATUS_MAP: Record<StatusOption, JobStatus | undefined> = {
+  draft: "DRAFT",
+  published: "PUBLISHED",
+  closed: "CLOSED",
+  all: undefined,
+};
+
+function getParam(params: SearchParams, key: string): string | undefined {
+  const value = params[key];
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function parseDate(value?: string | null): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function parseFilters(searchParams: SearchParams): ParsedFilters {
+  const moderationParam = (getParam(searchParams, "moderation") ?? "pending").toLowerCase() as ModerationOption;
+  const statusParam = (getParam(searchParams, "status") ?? "all").toLowerCase() as StatusOption;
+  const featuredParam = getParam(searchParams, "featured");
+  const userParam = getParam(searchParams, "user") ?? undefined;
+  const searchParam = getParam(searchParams, "q") ?? undefined;
+  const dateFromParam = getParam(searchParams, "dateFrom") ?? undefined;
+  const dateToParam = getParam(searchParams, "dateTo") ?? undefined;
+  const pageParam = Number.parseInt(getParam(searchParams, "page") ?? "1", 10);
+
+  const moderation = MODERATION_MAP[moderationParam] ?? "PENDING";
+  const status = STATUS_MAP[statusParam];
+  const featured = featuredParam === "1" ? "ONLY" : featuredParam === "0" ? "NONE" : undefined;
+  const page = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
+
+  return {
+    moderation,
+    status,
+    featured,
+    userQuery: userParam?.trim() ? userParam.trim() : undefined,
+    search: searchParam?.trim() ? searchParam.trim() : undefined,
+    dateFrom: parseDate(dateFromParam),
+    dateTo: parseDate(dateToParam),
+    featuredRaw: featuredParam ?? undefined,
+    moderationRaw: moderationParam,
+    statusRaw: statusParam,
+    userRaw: userParam ?? undefined,
+    searchRaw: searchParam ?? undefined,
+    dateFromRaw: dateFromParam ?? undefined,
+    dateToRaw: dateToParam ?? undefined,
+    page,
+  } satisfies ParsedFilters;
+}
+
+function buildQuery(base: ParsedFilters, overrides: Record<string, string | undefined>): string {
+  const params = new URLSearchParams();
+
+  const entries: Record<string, string | undefined> = {
+    moderation: base.moderationRaw,
+    status: base.statusRaw,
+    featured: base.featuredRaw,
+    user: base.userRaw,
+    q: base.searchRaw,
+    dateFrom: base.dateFromRaw,
+    dateTo: base.dateToRaw,
+    page: base.page.toString(),
+    ...overrides,
+  };
+
+  for (const [key, value] of Object.entries(entries)) {
+    if (value && value.length > 0) {
+      params.set(key, value);
+    }
+  }
+
+  if (!params.has("page")) {
+    params.set("page", "1");
+  }
+
+  const queryString = params.toString();
+  return queryString.length > 0 ? `?${queryString}` : "";
+}
+
+export default async function AdminJobsPage({ searchParams }: { searchParams: SearchParams }) {
+  const session = await getServerAuthSession();
+  if (!session?.user || session.user.role !== "ADMIN") {
+    notFound();
+  }
+
+  const parsed = parseFilters(searchParams);
+
+  const result = await listJobsForAdmin(
+    {
+      moderation: parsed.moderation,
+      status: parsed.status,
+      featured: parsed.featured,
+      userQuery: parsed.userQuery,
+      search: parsed.search,
+      dateFrom: parsed.dateFrom,
+      dateTo: parsed.dateTo,
+    },
+    { page: parsed.page, pageSize: PAGE_SIZE },
+  );
+
+  const jobs: JobAdminRow[] = result.items.map((item) => ({
+    id: item.id,
+    title: item.title,
+    status: item.status,
+    moderation: item.moderation,
+    featuredUntil: item.featuredUntil ? item.featuredUntil.toISOString() : null,
+    createdAt: item.createdAt.toISOString(),
+    owner: {
+      id: item.user.id,
+      name: item.user.name,
+    },
+  }));
+
+  const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize));
+  const hasPrevious = parsed.page > 1;
+  const hasNext = parsed.page < totalPages;
+
+  const totalLabel = new Intl.NumberFormat("fa-IR").format(result.total);
+
+  return (
+    <div className="space-y-6" dir="rtl">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold">مدیریت آگهی‌های شغلی</h1>
+        <p className="text-sm text-muted-foreground">
+          بررسی و مدیریت وضعیت آگهی‌های کاربران، تغییر ویژه‌سازی و بستن آگهی‌ها.
+        </p>
+      </header>
+
+      <section className="rounded-lg border border-border bg-background p-4 shadow-sm">
+        <form className="grid grid-cols-1 gap-4 lg:grid-cols-6" method="get">
+          <input type="hidden" name="page" value="1" />
+          <div className="space-y-2">
+            <Label htmlFor="moderation">وضعیت بررسی</Label>
+            <Select defaultValue={parsed.moderationRaw ?? "pending"} name="moderation">
+              <SelectTrigger id="moderation">
+                <SelectValue placeholder="وضعیت بررسی" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                <SelectItem value="pending">در انتظار</SelectItem>
+                <SelectItem value="approved">تأیید شده</SelectItem>
+                <SelectItem value="rejected">رد شده</SelectItem>
+                <SelectItem value="suspended">معلق</SelectItem>
+                <SelectItem value="all">همه</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="status">وضعیت انتشار</Label>
+            <Select defaultValue={parsed.statusRaw ?? "all"} name="status">
+              <SelectTrigger id="status">
+                <SelectValue placeholder="وضعیت انتشار" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                <SelectItem value="all">همه</SelectItem>
+                <SelectItem value="draft">پیش‌نویس</SelectItem>
+                <SelectItem value="published">منتشرشده</SelectItem>
+                <SelectItem value="closed">بسته</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="featured">ویژه بودن</Label>
+            <Select defaultValue={parsed.featuredRaw ?? ""} name="featured">
+              <SelectTrigger id="featured">
+                <SelectValue placeholder="همه" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                <SelectItem value="">همه</SelectItem>
+                <SelectItem value="1">فقط ویژه</SelectItem>
+                <SelectItem value="0">غیر ویژه</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="user">مالک آگهی</Label>
+            <Input id="user" name="user" placeholder="نام یا ایمیل" defaultValue={parsed.userRaw ?? ""} />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="q">جستجو در عنوان/توضیح</Label>
+            <Input id="q" name="q" placeholder="عبارت مورد نظر" defaultValue={parsed.searchRaw ?? ""} />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="dateFrom">تاریخ ایجاد از</Label>
+            <Input id="dateFrom" type="date" name="dateFrom" defaultValue={parsed.dateFromRaw ?? ""} />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="dateTo">تاریخ ایجاد تا</Label>
+            <Input id="dateTo" type="date" name="dateTo" defaultValue={parsed.dateToRaw ?? ""} />
+          </div>
+
+          <div className="flex items-end gap-2 lg:col-span-6">
+            <Button type="submit">اعمال فیلترها</Button>
+            <Button variant="ghost" asChild>
+              <Link href="/admin/jobs">حذف فیلترها</Link>
+            </Button>
+          </div>
+        </form>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+          <span>کل آگهی‌ها: {totalLabel}</span>
+          <span>
+            صفحه {parsed.page} از {totalPages}
+          </span>
+        </div>
+        <JobsAdminTable jobs={jobs} />
+        <div className="flex items-center justify-between gap-4">
+          <Button
+            variant="outline"
+            size="sm"
+            asChild
+            disabled={!hasPrevious}
+            className="min-w-24"
+          >
+            <Link href={buildQuery(parsed, { page: hasPrevious ? String(parsed.page - 1) : undefined })}>
+              قبلی
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            asChild
+            disabled={!hasNext}
+            className="min-w-24"
+          >
+            <Link href={buildQuery(parsed, { page: hasNext ? String(parsed.page + 1) : undefined })}>
+              بعدی
+            </Link>
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/components/admin/jobs/FeatureControls.tsx
+++ b/apps/web/components/admin/jobs/FeatureControls.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { featureJobAction } from "@/app/(admin)/admin/jobs/actions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/use-toast";
+
+type FeatureControlsProps = {
+  jobId: string;
+  featuredUntil?: string | null;
+};
+
+const PRESET_OPTIONS = [7, 14, 30] as const;
+const ERROR_MESSAGE = "خطایی رخ داد. لطفاً دوباره تلاش کنید.";
+
+function isFeaturedActive(featuredUntil?: string | null): boolean {
+  if (!featuredUntil) {
+    return false;
+  }
+  const date = new Date(featuredUntil);
+  if (Number.isNaN(date.getTime())) {
+    return false;
+  }
+  return date.getTime() > Date.now();
+}
+
+function getPersianDateLabel(value?: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return new Intl.DateTimeFormat("fa-IR", { dateStyle: "medium" }).format(date);
+}
+
+function formatInputDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function getMinDate(): string {
+  const nextDay = new Date();
+  nextDay.setHours(0, 0, 0, 0);
+  nextDay.setDate(nextDay.getDate() + 1);
+  return formatInputDate(nextDay);
+}
+
+function getMaxDate(): string {
+  const limit = new Date();
+  limit.setHours(0, 0, 0, 0);
+  limit.setDate(limit.getDate() + 60);
+  return formatInputDate(limit);
+}
+
+export function FeatureControls({ jobId, featuredUntil }: FeatureControlsProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [customDate, setCustomDate] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const isActive = isFeaturedActive(featuredUntil);
+  const featuredLabel = useMemo(() => getPersianDateLabel(featuredUntil), [featuredUntil]);
+
+  const handleAction = (command: Parameters<typeof featureJobAction>[1]) => {
+    startTransition(() => {
+      featureJobAction(jobId, command)
+        .then((result) => {
+          if (result.ok) {
+            toast({
+              title:
+                command.type === "CLEAR"
+                  ? "ویژه‌سازی آگهی لغو شد."
+                  : "آگهی به صورت ویژه نمایش داده می‌شود.",
+            });
+            setOpen(false);
+            setCustomDate("");
+            router.refresh();
+          } else {
+            toast({ variant: "destructive", title: "خطا", description: result.error ?? ERROR_MESSAGE });
+          }
+        })
+        .catch(() => {
+          toast({ variant: "destructive", title: "خطا", description: ERROR_MESSAGE });
+        });
+    });
+  };
+
+  const handlePreset = (days: (typeof PRESET_OPTIONS)[number]) => {
+    handleAction({ type: "PRESET", days });
+  };
+
+  const handleCustomSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!customDate) {
+      toast({
+        variant: "destructive",
+        title: "خطا",
+        description: "لطفاً تاریخ را انتخاب کنید.",
+      });
+      return;
+    }
+
+    handleAction({ type: "CUSTOM", until: customDate });
+  };
+
+  const toggleOpen = () => setOpen((prev) => !prev);
+
+  return (
+    <div className="relative">
+      <Button size="sm" variant="secondary" onClick={toggleOpen} disabled={isPending}>
+        {isActive ? "مدیریت ویژه" : "ویژه کردن"}
+      </Button>
+      {open ? (
+        <div className="absolute left-0 z-20 mt-2 w-64 rounded-lg border border-border bg-background p-4 shadow-lg" dir="rtl">
+          <div className="space-y-2 text-sm">
+            <p className="font-medium">مدیریت ویژه‌سازی</p>
+            {featuredLabel ? (
+              <p className="text-muted-foreground">وضعیت کنونی: ویژه تا {featuredLabel}</p>
+            ) : (
+              <p className="text-muted-foreground">در حال حاضر ویژه نیست.</p>
+            )}
+          </div>
+          <div className="mt-4 space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">افزودن مدت زمان</p>
+            <div className="flex flex-wrap gap-2">
+              {PRESET_OPTIONS.map((days) => (
+                <Button
+                  key={days}
+                  size="sm"
+                  variant="outline"
+                  disabled={isPending}
+                  onClick={() => handlePreset(days)}
+                >
+                  {days} روز
+                </Button>
+              ))}
+            </div>
+            <form className="space-y-2" onSubmit={handleCustomSubmit}>
+              <label className="block text-xs font-medium text-muted-foreground" htmlFor={`feature-date-${jobId}`}>
+                تاریخ دلخواه
+              </label>
+              <Input
+                id={`feature-date-${jobId}`}
+                type="date"
+                min={getMinDate()}
+                max={getMaxDate()}
+                value={customDate}
+                onChange={(event) => setCustomDate(event.target.value)}
+                disabled={isPending}
+              />
+              <Button type="submit" size="sm" className="w-full" disabled={isPending}>
+                ثبت تاریخ
+              </Button>
+            </form>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="w-full justify-center text-destructive"
+              disabled={isPending}
+              onClick={() => handleAction({ type: "CLEAR" })}
+            >
+              لغو ویژه‌سازی
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/admin/jobs/JobsAdminTable.tsx
+++ b/apps/web/components/admin/jobs/JobsAdminTable.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useMemo, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import type { JobModeration, JobStatus } from "@prisma/client";
+
+import { closeJobAction } from "@/app/(admin)/admin/jobs/actions";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useToast } from "@/components/ui/use-toast";
+
+import { FeatureControls } from "./FeatureControls";
+import { ModerationControls } from "./ModerationControls";
+import { StatusPills } from "./StatusPills";
+
+const ERROR_MESSAGE = "خطایی رخ داد. لطفاً دوباره تلاش کنید.";
+
+export type JobAdminRow = {
+  id: string;
+  title: string;
+  status: JobStatus;
+  moderation: JobModeration;
+  featuredUntil: string | null;
+  createdAt: string;
+  owner: {
+    id: string;
+    name: string | null;
+  };
+};
+
+type JobsAdminTableProps = {
+  jobs: JobAdminRow[];
+};
+
+function formatPersianDate(value: string): string {
+  return new Intl.DateTimeFormat("fa-IR", { dateStyle: "medium" }).format(new Date(value));
+}
+
+function formatOwnerName(name: string | null): string {
+  const trimmed = name?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : "بدون نام";
+}
+
+function CloseJobButton({ jobId }: { jobId: string }) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+
+  const handleClose = () => {
+    const confirmed = window.confirm("آیا از بستن آگهی اطمینان دارید؟");
+    if (!confirmed) {
+      return;
+    }
+
+    startTransition(() => {
+      closeJobAction(jobId)
+        .then((result) => {
+          if (result.ok) {
+            toast({ title: "آگهی بسته شد." });
+            router.refresh();
+          } else {
+            toast({ variant: "destructive", title: "خطا", description: result.error ?? ERROR_MESSAGE });
+          }
+        })
+        .catch(() => {
+          toast({ variant: "destructive", title: "خطا", description: ERROR_MESSAGE });
+        });
+    });
+  };
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      className="text-destructive"
+      disabled={isPending}
+      onClick={handleClose}
+    >
+      بستن آگهی
+    </Button>
+  );
+}
+
+export function JobsAdminTable({ jobs }: JobsAdminTableProps) {
+  const rows = useMemo(
+    () =>
+      jobs.map((job) => ({
+        ...job,
+        createdAtLabel: formatPersianDate(job.createdAt),
+        ownerName: formatOwnerName(job.owner.name),
+      })),
+    [jobs],
+  );
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>عنوان</TableHead>
+            <TableHead>مالک</TableHead>
+            <TableHead>وضعیت</TableHead>
+            <TableHead>تاریخ ایجاد</TableHead>
+            <TableHead>عملیات</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={5} className="py-10 text-center text-muted-foreground">
+                آگهی‌ای برای نمایش وجود ندارد.
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell className="whitespace-nowrap font-medium">
+                  <Link href={`/jobs/${row.id}`} className="hover:underline">
+                    {row.title}
+                  </Link>
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                  <div className="flex flex-col">
+                    <span>{row.ownerName}</span>
+                    <Link href={`/admin/users/${row.owner.id}`} className="text-xs text-primary hover:underline">
+                      شناسه: {row.owner.id}
+                    </Link>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <StatusPills
+                    status={row.status}
+                    moderation={row.moderation}
+                    featuredUntil={row.featuredUntil}
+                  />
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                  {row.createdAtLabel}
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-col gap-3">
+                    <ModerationControls jobId={row.id} moderation={row.moderation} />
+                    <div className="flex flex-wrap items-center gap-2">
+                      <FeatureControls jobId={row.id} featuredUntil={row.featuredUntil} />
+                      {row.status !== "CLOSED" ? <CloseJobButton jobId={row.id} /> : null}
+                    </div>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/web/components/admin/jobs/ModerationControls.tsx
+++ b/apps/web/components/admin/jobs/ModerationControls.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { type JobModeration } from "@prisma/client";
+
+import { approveJobAction, rejectJobAction, suspendJobAction } from "@/app/(admin)/admin/jobs/actions";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+
+const SUCCESS_MESSAGES = {
+  approve: "آگهی تأیید شد.",
+  reject: "آگهی رد شد و به مالک اطلاع داده شد.",
+  suspend: "آگهی معلق شد.",
+} as const;
+
+const ERROR_MESSAGE = "خطایی رخ داد. لطفاً دوباره تلاش کنید.";
+
+type ModerationControlsProps = {
+  jobId: string;
+  moderation: JobModeration;
+};
+
+function shouldShowApprove(moderation: JobModeration): boolean {
+  return (
+    moderation === "PENDING" ||
+    moderation === "REJECTED" ||
+    moderation === "SUSPENDED"
+  );
+}
+
+function shouldShowReject(moderation: JobModeration): boolean {
+  return moderation === "PENDING" || moderation === "APPROVED" || moderation === "SUSPENDED";
+}
+
+function shouldShowSuspend(moderation: JobModeration): boolean {
+  return moderation !== "SUSPENDED";
+}
+
+export function ModerationControls({ jobId, moderation }: ModerationControlsProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+
+  const handleApprove = () => {
+    startTransition(() => {
+      approveJobAction(jobId)
+        .then((result) => {
+          if (result.ok) {
+            toast({ title: SUCCESS_MESSAGES.approve });
+            router.refresh();
+          } else {
+            toast({ variant: "destructive", title: "خطا", description: result.error ?? ERROR_MESSAGE });
+          }
+        })
+        .catch(() => {
+          toast({ variant: "destructive", title: "خطا", description: ERROR_MESSAGE });
+        });
+    });
+  };
+
+  const handleReject = () => {
+    const note = window.prompt("دلیل رد آگهی را وارد کنید (اختیاری)");
+
+    startTransition(() => {
+      rejectJobAction(jobId, note ?? undefined)
+        .then((result) => {
+          if (result.ok) {
+            toast({ title: SUCCESS_MESSAGES.reject });
+            router.refresh();
+          } else {
+            toast({ variant: "destructive", title: "خطا", description: result.error ?? ERROR_MESSAGE });
+          }
+        })
+        .catch(() => {
+          toast({ variant: "destructive", title: "خطا", description: ERROR_MESSAGE });
+        });
+    });
+  };
+
+  const handleSuspend = () => {
+    const note = window.prompt("دلیل تعلیق را وارد کنید (اختیاری)");
+
+    startTransition(() => {
+      suspendJobAction(jobId, note ?? undefined)
+        .then((result) => {
+          if (result.ok) {
+            toast({ title: SUCCESS_MESSAGES.suspend });
+            router.refresh();
+          } else {
+            toast({ variant: "destructive", title: "خطا", description: result.error ?? ERROR_MESSAGE });
+          }
+        })
+        .catch(() => {
+          toast({ variant: "destructive", title: "خطا", description: ERROR_MESSAGE });
+        });
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {shouldShowApprove(moderation) ? (
+        <Button size="sm" variant="secondary" disabled={isPending} onClick={handleApprove}>
+          تأیید
+        </Button>
+      ) : null}
+      {shouldShowReject(moderation) ? (
+        <Button size="sm" variant="destructive" disabled={isPending} onClick={handleReject}>
+          رد کردن
+        </Button>
+      ) : null}
+      {shouldShowSuspend(moderation) ? (
+        <Button size="sm" variant="outline" disabled={isPending} onClick={handleSuspend}>
+          تعلیق
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/admin/jobs/StatusPills.tsx
+++ b/apps/web/components/admin/jobs/StatusPills.tsx
@@ -1,0 +1,58 @@
+import type { JobModeration, JobStatus } from "@prisma/client";
+
+import { Badge } from "@/components/ui/badge";
+
+type StatusPillsProps = {
+  status: JobStatus;
+  moderation: JobModeration;
+  featuredUntil?: string | null;
+};
+
+const STATUS_LABELS: Record<JobStatus, string> = {
+  DRAFT: "پیش‌نویس",
+  PUBLISHED: "منتشرشده",
+  CLOSED: "بسته",
+};
+
+const STATUS_VARIANT: Record<JobStatus, "outline" | "secondary" | "destructive" | "success"> = {
+  DRAFT: "secondary",
+  PUBLISHED: "success",
+  CLOSED: "destructive",
+};
+
+const MODERATION_LABELS: Record<JobModeration, string> = {
+  PENDING: "در انتظار",
+  APPROVED: "تأیید شده",
+  REJECTED: "رد شده",
+  SUSPENDED: "معلق",
+};
+
+const MODERATION_VARIANT: Record<JobModeration, "secondary" | "success" | "destructive" | "warning"> = {
+  PENDING: "secondary",
+  APPROVED: "success",
+  REJECTED: "destructive",
+  SUSPENDED: "warning",
+};
+
+function isFeaturedActive(featuredUntil?: string | null): boolean {
+  if (!featuredUntil) {
+    return false;
+  }
+  const date = new Date(featuredUntil);
+  if (Number.isNaN(date.getTime())) {
+    return false;
+  }
+  return date.getTime() > Date.now();
+}
+
+export function StatusPills({ status, moderation, featuredUntil }: StatusPillsProps) {
+  const featuredActive = isFeaturedActive(featuredUntil);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge variant={STATUS_VARIANT[status]}>{STATUS_LABELS[status]}</Badge>
+      <Badge variant={MODERATION_VARIANT[moderation]}>{MODERATION_LABELS[moderation]}</Badge>
+      {featuredActive ? <Badge variant="warning">ویژه</Badge> : null}
+    </div>
+  );
+}

--- a/apps/web/lib/jobs/admin/approveJob.ts
+++ b/apps/web/lib/jobs/admin/approveJob.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { JobModeration } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { revalidateJobRelatedPaths } from "@/lib/jobs/revalidate";
+import { emitJobApproved } from "@/lib/notifications/events";
+
+import {
+  JOB_ADMIN_SELECT,
+  JobAdminAction,
+  buildJobNotificationInfo,
+  ensureModerationTransition,
+  getJobForAdmin,
+} from "./common";
+
+export async function approveJobAdmin(jobId: string, adminId: string) {
+  const job = await getJobForAdmin(jobId);
+
+  if (job.moderation === JobModeration.APPROVED) {
+    return job;
+  }
+
+  ensureModerationTransition(
+    job.moderation,
+    [JobModeration.PENDING, JobModeration.REJECTED, JobModeration.SUSPENDED],
+    JobModeration.APPROVED,
+  );
+
+  const [updated] = await prisma.$transaction([
+    prisma.job.update({
+      where: { id: jobId },
+      data: { moderation: JobModeration.APPROVED },
+      select: JOB_ADMIN_SELECT,
+    }),
+    prisma.jobModerationEvent.create({
+      data: {
+        jobId,
+        adminId,
+        action: JobAdminAction.APPROVE,
+        note: null,
+      },
+    }),
+  ]);
+
+  await revalidateJobRelatedPaths(jobId);
+
+  await emitJobApproved(buildJobNotificationInfo(updated));
+
+  return updated;
+}

--- a/apps/web/lib/jobs/admin/closeJobAdmin.ts
+++ b/apps/web/lib/jobs/admin/closeJobAdmin.ts
@@ -1,0 +1,44 @@
+"use server";
+
+import { JobStatus } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { revalidateJobRelatedPaths } from "@/lib/jobs/revalidate";
+import { emitJobClosed } from "@/lib/notifications/events";
+
+import {
+  JOB_ADMIN_SELECT,
+  JobAdminAction,
+  buildJobNotificationInfo,
+  getJobForAdmin,
+} from "./common";
+
+export async function closeJobByAdmin(jobId: string, adminId: string) {
+  const job = await getJobForAdmin(jobId);
+
+  if (job.status === JobStatus.CLOSED) {
+    return job;
+  }
+
+  const [updated] = await prisma.$transaction([
+    prisma.job.update({
+      where: { id: jobId },
+      data: { status: JobStatus.CLOSED },
+      select: JOB_ADMIN_SELECT,
+    }),
+    prisma.jobModerationEvent.create({
+      data: {
+        jobId,
+        adminId,
+        action: JobAdminAction.CLOSE,
+        note: null,
+      },
+    }),
+  ]);
+
+  await revalidateJobRelatedPaths(jobId);
+
+  await emitJobClosed(buildJobNotificationInfo(updated));
+
+  return updated;
+}

--- a/apps/web/lib/jobs/admin/common.ts
+++ b/apps/web/lib/jobs/admin/common.ts
@@ -1,0 +1,98 @@
+"use server";
+
+import { JobAdminAction, JobModeration, JobStatus, Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+import { JobNotFoundError } from "../errors";
+
+export class AdminActionForbiddenError extends Error {
+  readonly code = "ADMIN_ACTION_FORBIDDEN" as const;
+
+  constructor(message = "دسترسی به این عملیات مجاز نیست.") {
+    super(message);
+    this.name = "AdminActionForbiddenError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class InvalidModerationTransitionError extends Error {
+  readonly code = "INVALID_MODERATION_TRANSITION" as const;
+
+  constructor(message = "تغییر وضعیت مجاز نیست.") {
+    super(message);
+    this.name = "InvalidModerationTransitionError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class InvalidFeatureScheduleError extends Error {
+  readonly code = "INVALID_FEATURE_SCHEDULE" as const;
+
+  constructor(message = "زمان ویژه‌سازی معتبر نیست.") {
+    super(message);
+    this.name = "InvalidFeatureScheduleError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export const JOB_ADMIN_SELECT = {
+  id: true,
+  userId: true,
+  title: true,
+  status: true,
+  moderation: true,
+  featuredUntil: true,
+  createdAt: true,
+} satisfies Prisma.JobSelect;
+
+export type JobAdminSnapshot = Prisma.JobGetPayload<{ select: typeof JOB_ADMIN_SELECT }>;
+
+export async function getJobForAdmin(jobId: string): Promise<JobAdminSnapshot> {
+  const job = await prisma.job.findUnique({
+    where: { id: jobId },
+    select: JOB_ADMIN_SELECT,
+  });
+
+  if (!job) {
+    throw new JobNotFoundError("آگهی موردنظر پیدا نشد.");
+  }
+
+  return job;
+}
+
+export function isJobFeatured(job: { featuredUntil: Date | null }, referenceDate = new Date()): boolean {
+  return Boolean(job.featuredUntil && job.featuredUntil.getTime() > referenceDate.getTime());
+}
+
+export type JobNotificationInfo = {
+  userId: string;
+  jobId: string;
+  jobTitle: string;
+  jobStatus: JobStatus;
+};
+
+export function buildJobNotificationInfo(job: JobAdminSnapshot): JobNotificationInfo {
+  return {
+    userId: job.userId,
+    jobId: job.id,
+    jobTitle: job.title,
+    jobStatus: job.status,
+  };
+}
+
+export function ensureModerationTransition(
+  current: JobModeration,
+  allowed: JobModeration[],
+  target: JobModeration,
+): void {
+  if (current === target) {
+    return;
+  }
+
+  if (!allowed.includes(current)) {
+    throw new InvalidModerationTransitionError();
+  }
+}
+
+export { JobAdminAction };

--- a/apps/web/lib/jobs/admin/featureJob.ts
+++ b/apps/web/lib/jobs/admin/featureJob.ts
@@ -1,0 +1,103 @@
+"use server";
+
+import { JobAdminAction } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { revalidateJobRelatedPaths } from "@/lib/jobs/revalidate";
+import { emitJobFeatured, emitJobUnfeatured } from "@/lib/notifications/events";
+
+import {
+  JOB_ADMIN_SELECT,
+  InvalidFeatureScheduleError,
+  buildJobNotificationInfo,
+  getJobForAdmin,
+  isJobFeatured,
+} from "./common";
+
+export type FeatureJobCommand =
+  | { type: "PRESET"; days: number }
+  | { type: "CUSTOM"; until: Date }
+  | { type: "CLEAR" };
+
+const MAX_CUSTOM_DAYS = 60;
+
+function getCustomDateTarget(date: Date): Date {
+  const normalized = new Date(date);
+  normalized.setHours(23, 59, 59, 999);
+  return normalized;
+}
+
+export async function featureJobAdmin(jobId: string, adminId: string, command: FeatureJobCommand) {
+  const job = await getJobForAdmin(jobId);
+  const now = new Date();
+
+  let nextFeaturedUntil: Date | null = job.featuredUntil ?? null;
+  let action: JobAdminAction = JobAdminAction.FEATURE;
+
+  if (command.type === "CLEAR") {
+    if (!isJobFeatured(job, now)) {
+      return job;
+    }
+    nextFeaturedUntil = null;
+    action = JobAdminAction.UNFEATURE;
+  } else if (command.type === "PRESET") {
+    if (!Number.isFinite(command.days) || command.days <= 0) {
+      throw new InvalidFeatureScheduleError();
+    }
+    const base = isJobFeatured(job, now) && job.featuredUntil ? job.featuredUntil : now;
+    const baseDate = new Date(base);
+    baseDate.setDate(baseDate.getDate() + command.days);
+    nextFeaturedUntil = baseDate;
+    action = JobAdminAction.FEATURE;
+  } else if (command.type === "CUSTOM") {
+    const target = getCustomDateTarget(command.until);
+    const diffDays = Math.ceil((target.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+
+    if (target <= now) {
+      throw new InvalidFeatureScheduleError("تاریخ انتخاب شده باید در آینده باشد.");
+    }
+
+    if (diffDays > MAX_CUSTOM_DAYS) {
+      throw new InvalidFeatureScheduleError("حداکثر می‌توانید تا ۶۰ روز آینده ویژه کنید.");
+    }
+
+    nextFeaturedUntil = target;
+    action = JobAdminAction.FEATURE;
+  }
+
+  const previousValue = job.featuredUntil ? job.featuredUntil.getTime() : null;
+  const nextValue = nextFeaturedUntil ? nextFeaturedUntil.getTime() : null;
+
+  if (previousValue === nextValue) {
+    return job;
+  }
+
+  const [updated] = await prisma.$transaction([
+    prisma.job.update({
+      where: { id: jobId },
+      data: { featuredUntil: nextFeaturedUntil },
+      select: JOB_ADMIN_SELECT,
+    }),
+    prisma.jobModerationEvent.create({
+      data: {
+        jobId,
+        adminId,
+        action,
+        note: null,
+      },
+    }),
+  ]);
+
+  await revalidateJobRelatedPaths(jobId);
+
+  if (action === JobAdminAction.UNFEATURE) {
+    await emitJobUnfeatured(buildJobNotificationInfo(updated));
+  } else {
+    await emitJobFeatured({
+      ...buildJobNotificationInfo(updated),
+      featuredUntil: updated.featuredUntil ?? null,
+    });
+  }
+
+  return updated;
+}

--- a/apps/web/lib/jobs/admin/listJobs.ts
+++ b/apps/web/lib/jobs/admin/listJobs.ts
@@ -1,0 +1,122 @@
+"use server";
+
+import { Prisma, type JobModeration, type JobStatus } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+const JOB_LIST_SELECT = {
+  id: true,
+  title: true,
+  status: true,
+  moderation: true,
+  featuredUntil: true,
+  createdAt: true,
+  user: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+} satisfies Prisma.JobSelect;
+
+export type JobsAdminListFilters = {
+  moderation?: JobModeration;
+  status?: JobStatus;
+  featured?: "ONLY" | "NONE";
+  userQuery?: string;
+  search?: string;
+  dateFrom?: Date;
+  dateTo?: Date;
+};
+
+export type PaginationOptions = {
+  page: number;
+  pageSize: number;
+};
+
+export async function listJobsForAdmin(
+  filters: JobsAdminListFilters,
+  pagination: PaginationOptions,
+) {
+  const conditions: Prisma.JobWhereInput[] = [];
+  const now = new Date();
+
+  if (filters.moderation) {
+    conditions.push({ moderation: filters.moderation });
+  }
+
+  if (filters.status) {
+    conditions.push({ status: filters.status });
+  }
+
+  if (filters.featured === "ONLY") {
+    conditions.push({ featuredUntil: { gt: now } });
+  } else if (filters.featured === "NONE") {
+    conditions.push({
+      OR: [
+        { featuredUntil: null },
+        { featuredUntil: { lte: now } },
+      ],
+    });
+  }
+
+  if (filters.userQuery) {
+    const query = filters.userQuery.trim();
+    if (query.length > 0) {
+      conditions.push({
+        user: {
+          OR: [
+            { name: { contains: query, mode: "insensitive" } },
+            { email: { contains: query, mode: "insensitive" } },
+          ],
+        },
+      });
+    }
+  }
+
+  if (filters.search) {
+    const search = filters.search.trim();
+    if (search.length > 0) {
+      conditions.push({
+        OR: [
+          { title: { contains: search, mode: "insensitive" } },
+          { description: { contains: search, mode: "insensitive" } },
+        ],
+      });
+    }
+  }
+
+  if (filters.dateFrom) {
+    conditions.push({ createdAt: { gte: filters.dateFrom } });
+  }
+
+  if (filters.dateTo) {
+    conditions.push({ createdAt: { lte: filters.dateTo } });
+  }
+
+  const where: Prisma.JobWhereInput | undefined = conditions.length
+    ? { AND: conditions }
+    : undefined;
+
+  const page = Math.max(1, pagination.page);
+  const pageSize = Math.max(1, pagination.pageSize);
+  const skip = (page - 1) * pageSize;
+
+  const [items, total] = await prisma.$transaction([
+    prisma.job.findMany({
+      where,
+      select: JOB_LIST_SELECT,
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: pageSize,
+    }),
+    prisma.job.count({ where }),
+  ]);
+
+  return {
+    items,
+    total,
+    page,
+    pageSize,
+  };
+}

--- a/apps/web/lib/jobs/admin/rejectJob.ts
+++ b/apps/web/lib/jobs/admin/rejectJob.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { JobModeration } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { revalidateJobRelatedPaths } from "@/lib/jobs/revalidate";
+import { emitJobRejected } from "@/lib/notifications/events";
+
+import {
+  JOB_ADMIN_SELECT,
+  JobAdminAction,
+  buildJobNotificationInfo,
+  ensureModerationTransition,
+  getJobForAdmin,
+} from "./common";
+
+export async function rejectJobAdmin(jobId: string, adminId: string, note?: string | null) {
+  const job = await getJobForAdmin(jobId);
+
+  const cleanedNote = note?.trim() ? note.trim() : null;
+
+  if (job.moderation === JobModeration.REJECTED && cleanedNote === null) {
+    return job;
+  }
+
+  ensureModerationTransition(
+    job.moderation,
+    [JobModeration.PENDING, JobModeration.APPROVED, JobModeration.SUSPENDED],
+    JobModeration.REJECTED,
+  );
+
+  const [updated] = await prisma.$transaction([
+    prisma.job.update({
+      where: { id: jobId },
+      data: { moderation: JobModeration.REJECTED },
+      select: JOB_ADMIN_SELECT,
+    }),
+    prisma.jobModerationEvent.create({
+      data: {
+        jobId,
+        adminId,
+        action: JobAdminAction.REJECT,
+        note: cleanedNote,
+      },
+    }),
+  ]);
+
+  await revalidateJobRelatedPaths(jobId);
+
+  await emitJobRejected({
+    ...buildJobNotificationInfo(updated),
+    note: cleanedNote ?? undefined,
+  });
+
+  return updated;
+}

--- a/apps/web/lib/jobs/admin/suspendJob.ts
+++ b/apps/web/lib/jobs/admin/suspendJob.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import { JobModeration } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { revalidateJobRelatedPaths } from "@/lib/jobs/revalidate";
+import { emitJobPending } from "@/lib/notifications/events";
+
+import {
+  JOB_ADMIN_SELECT,
+  JobAdminAction,
+  buildJobNotificationInfo,
+  ensureModerationTransition,
+  getJobForAdmin,
+} from "./common";
+
+export async function suspendJobAdmin(jobId: string, adminId: string, note?: string | null) {
+  const job = await getJobForAdmin(jobId);
+
+  const cleanedNote = note?.trim() ? note.trim() : null;
+
+  if (job.moderation === JobModeration.SUSPENDED && !cleanedNote) {
+    return job;
+  }
+
+  ensureModerationTransition(
+    job.moderation,
+    [JobModeration.PENDING, JobModeration.APPROVED, JobModeration.REJECTED],
+    JobModeration.SUSPENDED,
+  );
+
+  const [updated] = await prisma.$transaction([
+    prisma.job.update({
+      where: { id: jobId },
+      data: { moderation: JobModeration.SUSPENDED },
+      select: JOB_ADMIN_SELECT,
+    }),
+    prisma.jobModerationEvent.create({
+      data: {
+        jobId,
+        adminId,
+        action: JobAdminAction.SUSPEND,
+        note: cleanedNote,
+      },
+    }),
+  ]);
+
+  await revalidateJobRelatedPaths(jobId);
+
+  await emitJobPending({
+    ...buildJobNotificationInfo(updated),
+    action: "SUSPENDED",
+    note: cleanedNote ?? undefined,
+  });
+
+  return updated;
+}

--- a/apps/web/prisma/migrations/20251008000100_sprint3_jobs_admin_events/migration.sql
+++ b/apps/web/prisma/migrations/20251008000100_sprint3_jobs_admin_events/migration.sql
@@ -1,0 +1,21 @@
+-- CreateEnum
+CREATE TYPE "JobAdminAction" AS ENUM ('APPROVE', 'REJECT', 'SUSPEND', 'FEATURE', 'UNFEATURE', 'CLOSE');
+
+-- CreateTable
+CREATE TABLE "JobModerationEvent" (
+    "id" TEXT NOT NULL,
+    "jobId" TEXT NOT NULL,
+    "adminId" TEXT NOT NULL,
+    "action" "JobAdminAction" NOT NULL,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "JobModerationEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "JobModerationEvent_jobId_createdAt_idx" ON "JobModerationEvent"("jobId", "createdAt");
+CREATE INDEX "JobModerationEvent_adminId_idx" ON "JobModerationEvent"("adminId");
+
+-- AddForeignKey
+ALTER TABLE "JobModerationEvent" ADD CONSTRAINT "JobModerationEvent_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "Job"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "JobModerationEvent" ADD CONSTRAINT "JobModerationEvent_adminId_fkey" FOREIGN KEY ("adminId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   notifications     Notification[]
   emailLogs         EmailLog[]
   Job               Job[]
+  jobModerationEvents JobModerationEvent[] @relation("JobModerationAdmin")
 }
 
 model Profile {
@@ -203,10 +204,26 @@ model Job {
   createdAt     DateTime      @default(now())
   updatedAt     DateTime      @updatedAt
 
+  moderationEvents JobModerationEvent[]
+
   @@index([status, moderation, featuredUntil])
   @@index([category])
   @@index([cityId])
   @@index([title])
+}
+
+model JobModerationEvent {
+  id        String          @id @default(cuid())
+  jobId     String
+  job       Job             @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  adminId   String
+  admin     User            @relation("JobModerationAdmin", fields: [adminId], references: [id], onDelete: Restrict)
+  action    JobAdminAction
+  note      String?
+  createdAt DateTime        @default(now())
+
+  @@index([jobId, createdAt])
+  @@index([adminId])
 }
 
 enum ProductType {
@@ -304,6 +321,15 @@ enum JobModeration {
   APPROVED
   REJECTED
   SUSPENDED
+}
+
+enum JobAdminAction {
+  APPROVE
+  REJECT
+  SUSPEND
+  FEATURE
+  UNFEATURE
+  CLOSE
 }
 
 model Notification {


### PR DESCRIPTION
## Summary
- add an admin jobs queue with filters, pagination, and inline moderation/feature controls for each posting
- implement server actions and job admin services covering approve/reject/suspend/feature/close with notifications, audit logging, and revalidation hooks
- extend notifications/templates and Prisma schema to support job-specific messages and persisted moderation events

## Testing
- pnpm lint *(fails: blocked by registry proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e40abf5aa083278ea7146771ea68ea