### PR TITLE
feat: improve job caching and notifications

### DIFF
--- a/apps/web/lib/cache/config.ts
+++ b/apps/web/lib/cache/config.ts
@@ -1,0 +1,19 @@
+export const CACHE_TAGS = {
+  cities: "cities",
+  jobsFilters: "jobs:filters",
+  jobsList: "jobs:list",
+  jobDetail: (jobId: string) => `job:${jobId}`,
+  jobsListCity: (cityId: string) => `jobs:list:city:${cityId}`,
+  jobsListCategory: (category: string) => `jobs:list:category:${category}`,
+  jobsListRemote: (remote: boolean) => `jobs:list:remote:${remote ? 1 : 0}`,
+  jobsListPayType: (payType: string) => `jobs:list:payType:${payType}`,
+  jobsListSort: (sort: string) => `jobs:list:sort:${sort}`,
+  jobViews: (jobId: string) => `job:${jobId}:views`,
+} as const;
+
+export const CACHE_REVALIDATE = {
+  cities: 60 * 60 * 24,
+  jobFilters: 60 * 5,
+  jobsList: 60,
+  jobDetail: 60 * 2,
+} as const;

--- a/apps/web/lib/jobs/constants.ts
+++ b/apps/web/lib/jobs/constants.ts
@@ -1,0 +1,5 @@
+export const PUBLIC_JOBS_PAGE_SIZE = 12;
+
+export const PUBLIC_JOB_SORTS = ["newest", "featured", "expiring"] as const;
+
+export type PublicJobSort = (typeof PUBLIC_JOB_SORTS)[number];

--- a/apps/web/lib/jobs/publicQueries.ts
+++ b/apps/web/lib/jobs/publicQueries.ts
@@ -1,9 +1,14 @@
-import { prisma } from "@/lib/prisma";
+import { unstable_cache } from "next/cache";
+
 import { Prisma } from "@prisma/client";
 
-export const PUBLIC_JOBS_PAGE_SIZE = 12;
+import { CACHE_REVALIDATE, CACHE_TAGS } from "@/lib/cache/config";
+import { prisma } from "@/lib/prisma";
 
-export type PublicJobSort = "newest" | "featured" | "expiring";
+import { PUBLIC_JOB_SORTS, PUBLIC_JOBS_PAGE_SIZE, type PublicJobSort } from "./constants";
+
+export { PUBLIC_JOBS_PAGE_SIZE } from "./constants";
+export type { PublicJobSort } from "./constants";
 
 export type PublicJobQueryParams = {
   city?: string;
@@ -37,6 +42,62 @@ const BASE_VISIBILITY_WHERE: Prisma.JobWhereInput = {
   status: "PUBLISHED",
   moderation: "APPROVED",
 };
+
+type NormalizedPublicJobQueryParams = Required<Pick<PublicJobQueryParams, "remote" | "sort" | "page">> &
+  Omit<PublicJobQueryParams, "remote" | "sort" | "page">;
+
+function normalizePublicJobQueryParams(
+  params: PublicJobQueryParams = {},
+): NormalizedPublicJobQueryParams {
+  const page = Math.max(params.page ?? 1, 1);
+  let sort: PublicJobSort = "newest";
+
+  if (params.sort && PUBLIC_JOB_SORTS.includes(params.sort)) {
+    sort = params.sort;
+  }
+
+  return {
+    city: params.city,
+    category: params.category,
+    payType: params.payType,
+    remote: Boolean(params.remote),
+    sort,
+    page,
+  } satisfies NormalizedPublicJobQueryParams;
+}
+
+function buildCacheKey(params: NormalizedPublicJobQueryParams): string {
+  return JSON.stringify({
+    city: params.city ?? null,
+    category: params.category ?? null,
+    payType: params.payType ?? null,
+    remote: params.remote ? 1 : 0,
+    sort: params.sort,
+    page: params.page,
+  });
+}
+
+function buildJobsListTags(params: NormalizedPublicJobQueryParams): string[] {
+  const tags = new Set<string>([
+    CACHE_TAGS.jobsList,
+    CACHE_TAGS.jobsListSort(params.sort),
+    CACHE_TAGS.jobsListRemote(params.remote),
+  ]);
+
+  if (params.city) {
+    tags.add(CACHE_TAGS.jobsListCity(params.city));
+  }
+
+  if (params.category) {
+    tags.add(CACHE_TAGS.jobsListCategory(params.category));
+  }
+
+  if (params.payType) {
+    tags.add(CACHE_TAGS.jobsListPayType(params.payType));
+  }
+
+  return Array.from(tags);
+}
 
 export function buildPublicWhere(
   params: Pick<PublicJobQueryParams, "city" | "category" | "remote" | "payType">
@@ -85,51 +146,64 @@ export function buildPublicOrderBy(
 }
 
 export async function getPublicJobs(params: PublicJobQueryParams = {}) {
-  const page = Math.max(params.page ?? 1, 1);
-  const skip = (page - 1) * PUBLIC_JOBS_PAGE_SIZE;
+  const normalized = normalizePublicJobQueryParams(params);
+  const cacheKey = buildCacheKey(normalized);
+  const skip = (normalized.page - 1) * PUBLIC_JOBS_PAGE_SIZE;
+  const tags = buildJobsListTags(normalized);
 
-  const where = buildPublicWhere({
-    city: params.city,
-    category: params.category,
-    remote: params.remote,
-    payType: params.payType,
-  });
+  const resolve = unstable_cache(
+    async () => {
+      const where = buildPublicWhere({
+        city: normalized.city,
+        category: normalized.category,
+        remote: normalized.remote,
+        payType: normalized.payType,
+      });
 
-  const orderBy = buildPublicOrderBy(params.sort);
+      const orderBy = buildPublicOrderBy(normalized.sort);
 
-  const [items, total] = await Promise.all([
-    prisma.job.findMany({
-      where,
-      orderBy,
-      skip,
-      take: PUBLIC_JOBS_PAGE_SIZE,
-      include: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            profile: {
+      const [items, total] = await Promise.all([
+        prisma.job.findMany({
+          where,
+          orderBy,
+          skip,
+          take: PUBLIC_JOBS_PAGE_SIZE,
+          include: {
+            user: {
               select: {
                 id: true,
-                stageName: true,
-                firstName: true,
-                lastName: true,
+                name: true,
+                profile: {
+                  select: {
+                    id: true,
+                    stageName: true,
+                    firstName: true,
+                    lastName: true,
+                  },
+                },
               },
             },
           },
-        },
-      },
-    }),
-    prisma.job.count({ where }),
-  ]);
+        }),
+        prisma.job.count({ where }),
+      ]);
 
-  return {
-    items,
-    total,
-    page,
-    pageSize: PUBLIC_JOBS_PAGE_SIZE,
-    totalPages: Math.max(1, Math.ceil(total / PUBLIC_JOBS_PAGE_SIZE)),
-  };
+      return {
+        items,
+        total,
+        page: normalized.page,
+        pageSize: PUBLIC_JOBS_PAGE_SIZE,
+        totalPages: Math.max(1, Math.ceil(total / PUBLIC_JOBS_PAGE_SIZE)),
+      };
+    },
+    ["public-jobs", cacheKey],
+    {
+      revalidate: CACHE_REVALIDATE.jobsList,
+      tags,
+    },
+  );
+
+  return resolve();
 }
 
 export async function getPublicJobById(id: string) {
@@ -137,55 +211,76 @@ export async function getPublicJobById(id: string) {
     return null;
   }
 
-  return prisma.job.findFirst({
-    where: {
-      ...BASE_VISIBILITY_WHERE,
-      id,
-    },
-    include: {
-      user: {
-        select: {
-          id: true,
-          name: true,
-          profile: {
+  const resolve = unstable_cache(
+    async () =>
+      prisma.job.findFirst({
+        where: {
+          ...BASE_VISIBILITY_WHERE,
+          id,
+        },
+        include: {
+          user: {
             select: {
               id: true,
-              stageName: true,
-              firstName: true,
-              lastName: true,
+              name: true,
+              profile: {
+                select: {
+                  id: true,
+                  stageName: true,
+                  firstName: true,
+                  lastName: true,
+                },
+              },
             },
           },
         },
-      },
+      }),
+    ["public-job", id],
+    {
+      revalidate: CACHE_REVALIDATE.jobDetail,
+      tags: [CACHE_TAGS.jobDetail(id), CACHE_TAGS.jobsList],
     },
-  });
+  );
+
+  return resolve();
 }
 
 export async function getPublicJobFilters() {
-  const where = { ...BASE_VISIBILITY_WHERE } satisfies Prisma.JobWhereInput;
+  const resolve = unstable_cache(
+    async () => {
+      const where = { ...BASE_VISIBILITY_WHERE } satisfies Prisma.JobWhereInput;
 
-  const [categories, payTypes] = await Promise.all([
-    prisma.job.findMany({
-      where,
-      distinct: ["category"],
-      orderBy: { category: "asc" },
-      select: { category: true },
-    }),
-    prisma.job.findMany({
-      where: {
-        ...where,
-        payType: { not: null },
-      },
-      distinct: ["payType"],
-      orderBy: { payType: "asc" },
-      select: { payType: true },
-    }),
-  ]);
+      const [categories, payTypes] = await Promise.all([
+        prisma.job.findMany({
+          where,
+          distinct: ["category"],
+          orderBy: { category: "asc" },
+          select: { category: true },
+        }),
+        prisma.job.findMany({
+          where: {
+            ...where,
+            payType: { not: null },
+          },
+          distinct: ["payType"],
+          orderBy: { payType: "asc" },
+          select: { payType: true },
+        }),
+      ]);
 
-  return {
-    categories: categories.map((entry) => entry.category).filter(Boolean),
-    payTypes: payTypes
-      .map((entry) => entry.payType)
-      .filter((value): value is string => Boolean(value && value.trim())),
-  };
+      return {
+        categories: categories.map((entry) => entry.category).filter(Boolean),
+        payTypes: payTypes
+          .map((entry) => entry.payType)
+          .filter((value): value is string => Boolean(value && value.trim())),
+      };
+    },
+    ["public-job-filters"],
+    {
+      revalidate: CACHE_REVALIDATE.jobFilters,
+      tags: [CACHE_TAGS.jobsFilters, CACHE_TAGS.jobsList],
+    },
+  );
+
+  return resolve();
 }

--- a/apps/web/lib/jobs/revalidate.ts
+++ b/apps/web/lib/jobs/revalidate.ts
@@ -1,21 +1,55 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 
-export async function revalidateDashboardJobs(): Promise<void> {
-  revalidatePath("/dashboard/jobs");
-}
+import { CACHE_TAGS } from "@/lib/cache/config";
+import { prisma } from "@/lib/prisma";
 
-export async function revalidatePublicJobs(): Promise<void> {
-  revalidatePath("/jobs");
-}
+import { PUBLIC_JOB_SORTS } from "./constants";
 
-export async function revalidateJobDetail(jobId: string): Promise<void> {
-  revalidatePath(`/jobs/${jobId}`);
+export async function getJobTags(jobId: string): Promise<string[]> {
+  const job = await prisma.job.findUnique({
+    where: { id: jobId },
+    select: {
+      cityId: true,
+      category: true,
+      remote: true,
+      payType: true,
+    },
+  });
+
+  const tags = new Set<string>([
+    CACHE_TAGS.jobDetail(jobId),
+    CACHE_TAGS.jobsList,
+    CACHE_TAGS.jobsListRemote(true),
+    CACHE_TAGS.jobsListRemote(false),
+  ]);
+
+  for (const sort of PUBLIC_JOB_SORTS) {
+    tags.add(CACHE_TAGS.jobsListSort(sort));
+  }
+
+  if (job?.cityId) {
+    tags.add(CACHE_TAGS.jobsListCity(job.cityId));
+  }
+
+  if (job?.category) {
+    tags.add(CACHE_TAGS.jobsListCategory(job.category));
+  }
+
+  if (job?.payType) {
+    tags.add(CACHE_TAGS.jobsListPayType(job.payType));
+  }
+
+  return Array.from(tags);
 }
 
 export async function revalidateJobRelatedPaths(jobId: string): Promise<void> {
-  await revalidateDashboardJobs();
-  await revalidatePublicJobs();
-  await revalidateJobDetail(jobId);
+  const tags = await getJobTags(jobId);
+  const uniqueTags = new Set([...tags, CACHE_TAGS.jobsFilters]);
+
+  await Promise.all(Array.from(uniqueTags).map((tag) => revalidateTag(tag)));
+
+  // Keep dashboard pages fresh for authors/admins.
+  revalidatePath("/dashboard/jobs");
 }

--- a/apps/web/lib/jobs/views.ts
+++ b/apps/web/lib/jobs/views.ts
@@ -1,9 +1,38 @@
+import { cookies } from "next/headers";
+
 import { prisma } from "@/lib/prisma";
+
+const VIEW_COOKIE_PREFIX = "job-viewed";
+const VIEW_DEBOUNCE_MS = 30 * 60 * 1000; // 30 minutes
+
+function buildCookieName(jobId: string): string {
+  return `${VIEW_COOKIE_PREFIX}-${jobId}`;
+}
 
 export async function incrementJobViews(jobId: string): Promise<void> {
   if (!jobId) {
     return;
   }
+
+  const cookieStore = cookies();
+  const cookieName = buildCookieName(jobId);
+  const now = Date.now();
+  const existing = cookieStore.get(cookieName);
+
+  if (existing) {
+    const lastViewed = Number.parseInt(existing.value, 10);
+    if (!Number.isNaN(lastViewed) && now - lastViewed < VIEW_DEBOUNCE_MS) {
+      return;
+    }
+  }
+
+  cookieStore.set({
+    name: cookieName,
+    value: String(now),
+    httpOnly: true,
+    sameSite: "lax",
+    maxAge: Math.floor(VIEW_DEBOUNCE_MS / 1000),
+  });
 
   try {
     await prisma.job.update({

--- a/apps/web/lib/location/cities.ts
+++ b/apps/web/lib/location/cities.ts
@@ -1,10 +1,23 @@
+import { unstable_cache } from "next/cache";
+
+import { CACHE_REVALIDATE, CACHE_TAGS } from "@/lib/cache/config";
+
 export type City = { id: string; name: string };
 
-export async function getCities(): Promise<City[]> {
+async function loadCities(): Promise<City[]> {
   // TODO: replace with real list when provided
   return [
     { id: "tehran", name: "تهران" },
     { id: "isfahan", name: "اصفهان" },
     { id: "mashhad", name: "مشهد" },
   ];
+}
+
+const resolveCities = unstable_cache(loadCities, ["cities"], {
+  revalidate: CACHE_REVALIDATE.cities,
+  tags: [CACHE_TAGS.cities],
+});
+
+export async function getCities(): Promise<City[]> {
+  return resolveCities();
 }

--- a/apps/web/lib/location/revalidate.ts
+++ b/apps/web/lib/location/revalidate.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+import { CACHE_TAGS } from "@/lib/cache/config";
+
+export async function revalidateCities(): Promise<void> {
+  revalidateTag(CACHE_TAGS.cities);
+}

--- a/apps/web/lib/notifications/dispatcher.ts
+++ b/apps/web/lib/notifications/dispatcher.ts
@@ -5,6 +5,10 @@ import { NotificationChannel, NotificationType } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 
 import { isEmailConfigured, sendEmail } from "./email";
+import { emitNotificationDispatch } from "./instrumentation";
+
+export { setNotificationDispatchObserver } from "./instrumentation";
+export type { NotificationDispatchObserver, NotificationDispatchEvent } from "./instrumentation";
 
 type NotifyOptions = {
   userId: string;
@@ -40,58 +44,81 @@ function computeDedupeHash({
 
 export async function notifyOnce(options: NotifyOptions): Promise<void> {
   const { userId, type, title, body, payload, channels, dedupeKey } = options;
+  const requestedChannels = channels?.length ? channels : [NotificationChannel.IN_APP];
+  const start = Date.now();
   const hash = computeDedupeHash({ userId, type, body, payload: payload ?? undefined, dedupeKey });
+  let status: "delivered" | "duplicate" | "error" = "delivered";
+  let dispatchError: unknown;
 
-  const existing = await prisma.notification.findFirst({
-    where: {
-      userId,
-      type,
-      createdAt: {
-        gte: new Date(Date.now() - TEN_MINUTES_MS),
-      },
-      payload: {
-        path: ["dedupeKey"],
-        equals: hash,
-      },
-    },
-  });
-
-  if (existing) {
-    return;
-  }
-
-  const notificationPayload = {
-    ...(payload ?? {}),
-    dedupeKey: hash,
-  } satisfies Record<string, unknown>;
-
-  const requestedChannels = channels ?? [NotificationChannel.IN_APP, NotificationChannel.EMAIL];
-
-  if (requestedChannels.includes(NotificationChannel.IN_APP)) {
-    await prisma.notification.create({
-      data: {
+  try {
+    const existing = await prisma.notification.findFirst({
+      where: {
         userId,
         type,
-        title,
-        body,
-        payload: notificationPayload,
-        channel: NotificationChannel.IN_APP,
+        createdAt: {
+          gte: new Date(Date.now() - TEN_MINUTES_MS),
+        },
+        payload: {
+          path: ["dedupeKey"],
+          equals: hash,
+        },
       },
     });
-  }
 
-  const shouldSendEmail =
-    requestedChannels.includes(NotificationChannel.EMAIL) && isEmailConfigured();
+    if (existing) {
+      status = "duplicate";
+      return;
+    }
 
-  if (shouldSendEmail) {
-    try {
-      await sendEmail(userId, title, body);
-    } catch (error) {
-      console.error("[notifications] email_failed", {
-        userId,
-        type,
-        error,
+    const notificationPayload = {
+      ...(payload ?? {}),
+      dedupeKey: hash,
+      ...(dedupeKey ? { dedupeKeyRaw: dedupeKey } : {}),
+    } satisfies Record<string, unknown>;
+
+    if (requestedChannels.includes(NotificationChannel.IN_APP)) {
+      await prisma.notification.create({
+        data: {
+          userId,
+          type,
+          title,
+          body,
+          payload: notificationPayload,
+          channel: NotificationChannel.IN_APP,
+        },
       });
     }
+
+    const shouldSendEmail =
+      requestedChannels.includes(NotificationChannel.EMAIL) && isEmailConfigured();
+
+    if (shouldSendEmail) {
+      try {
+        await sendEmail(userId, title, body);
+      } catch (error) {
+        dispatchError = error;
+        status = "error";
+        console.error("[notifications] email_failed", {
+          userId,
+          type,
+          error,
+        });
+      }
+    }
+  } catch (error) {
+    status = "error";
+    dispatchError = error;
+    throw error;
+  } finally {
+    emitNotificationDispatch({
+      userId,
+      type,
+      channels: requestedChannels,
+      dedupeKey,
+      dedupeHash: hash,
+      status,
+      durationMs: Date.now() - start,
+      ...(dispatchError ? { error: dispatchError } : {}),
+    });
   }
 }

--- a/apps/web/lib/notifications/events.ts
+++ b/apps/web/lib/notifications/events.ts
@@ -226,6 +226,7 @@ export async function emitJobPending({
   });
 }
 
+// Job state change notifications stay IN_APP-only until additional channels are supported.
 export async function emitJobFeatured({
   userId,
   jobId,

--- a/apps/web/lib/notifications/instrumentation.ts
+++ b/apps/web/lib/notifications/instrumentation.ts
@@ -1,0 +1,50 @@
+import type { NotificationChannel, NotificationType } from "@prisma/client";
+
+export type NotificationDispatchStatus = "delivered" | "duplicate" | "error";
+
+export type NotificationDispatchEvent = {
+  userId: string;
+  type: NotificationType;
+  channels: NotificationChannel[];
+  dedupeKey?: string;
+  dedupeHash: string;
+  status: NotificationDispatchStatus;
+  durationMs: number;
+  error?: unknown;
+};
+
+export type NotificationDispatchObserver = (event: NotificationDispatchEvent) => void;
+
+let observer: NotificationDispatchObserver | null = (event) => {
+  const { status, ...rest } = event;
+  const payload = {
+    ...rest,
+    status,
+  };
+
+  if (status === "error") {
+    console.error("[notifications] dispatch_error", payload);
+  } else if (status === "duplicate") {
+    console.info("[notifications] dispatch_duplicate", payload);
+  } else {
+    console.info("[notifications] dispatch_delivered", payload);
+  }
+};
+
+export function setNotificationDispatchObserver(
+  nextObserver: NotificationDispatchObserver | null,
+): void {
+  observer = nextObserver;
+}
+
+export function getNotificationDispatchObserver(): NotificationDispatchObserver | null {
+  return observer;
+}
+
+export function emitNotificationDispatch(event: NotificationDispatchEvent): void {
+  try {
+    observer?.(event);
+  } catch (error) {
+    console.error("[notifications] dispatch_observer_failed", { error });
+  }
+}

--- a/apps/web/lib/notifications/replay.ts
+++ b/apps/web/lib/notifications/replay.ts
@@ -1,0 +1,76 @@
+import { NotificationChannel } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+import { notifyOnce } from "./dispatcher";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractPayload(
+  payload: unknown,
+): { payload?: Record<string, unknown>; dedupeKey?: string } {
+  if (!isRecord(payload)) {
+    return {};
+  }
+
+  const result: Record<string, unknown> = {};
+  let dedupeKey: string | undefined;
+
+  for (const [key, value] of Object.entries(payload)) {
+    if (key === "dedupeKeyRaw" && typeof value === "string") {
+      dedupeKey = value;
+      continue;
+    }
+
+    if (key === "dedupeKey") {
+      continue;
+    }
+
+    result[key] = value;
+  }
+
+  return {
+    payload: Object.keys(result).length > 0 ? result : undefined,
+    dedupeKey,
+  };
+}
+
+type ReplayOptions = {
+  channels?: NotificationChannel[];
+};
+
+export async function replayNotifications(
+  notificationIds: string[],
+  options: ReplayOptions = {},
+): Promise<void> {
+  if (notificationIds.length === 0) {
+    return;
+  }
+
+  const notifications = await prisma.notification.findMany({
+    where: { id: { in: notificationIds } },
+  });
+
+  const byId = new Map(notifications.map((notification) => [notification.id, notification]));
+
+  for (const id of notificationIds) {
+    const notification = byId.get(id);
+    if (!notification) {
+      continue;
+    }
+
+    const { payload, dedupeKey } = extractPayload(notification.payload);
+
+    await notifyOnce({
+      userId: notification.userId,
+      type: notification.type,
+      title: notification.title,
+      body: notification.body,
+      payload,
+      dedupeKey,
+      channels: options.channels ?? [notification.channel ?? NotificationChannel.IN_APP],
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add cache tag configuration and wrap public job queries, filters, and city lookups in tagged caches with shared constants
- switch job revalidation helpers to tag-based invalidation and throttle the view counter per session
- add notification dispatch instrumentation, default in-app delivery, and a replay helper for backfilling deduped notifications

## Testing
- pnpm --filter @app/web lint *(fails: network request blocked while downloading pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68e4204a85a88327a56d29581dbb482e