### PR TITLE
Fix Prisma CLI env resolution for web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 !.env.example
 !apps/web/.env
 !apps/web/.env.example
+!apps/web/prisma/.env
 pnpm-lock.yaml
 .DS_Store
 .idea

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,5 +1,5 @@
 # Environment variables for the @app/web application
 # Copy this file to .env and update the values as needed.
 
-DATABASE_URL="postgresql://arminiranpour@localhost:5432/casting?schema=public"
-NEXTAUTH_SECRET="development-next-auth-secret"  
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"
+NEXTAUTH_SECRET="development-next-auth-secret"

--- a/apps/web/prisma/.env
+++ b/apps/web/prisma/.env
@@ -1,0 +1,3 @@
+# Prisma CLI environment variables for @app/web
+# Update the connection string as needed for your local setup.
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"


### PR DESCRIPTION
## Summary
- allow the repository to track a Prisma-specific .env file for the web app
- provide a default DATABASE_URL for Prisma commands that run from the repo root
- align the app-level .env with the shared development connection string

## Testing
- not run (network access to install pnpm is blocked in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e4271a33508327a26e1bbce19caaec