### PR TITLE
Fix prisma command environment by proxying through @app/web

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ PUBLIC_BASE_URL="http://localhost:3000"
 After setting the environment variable you can run the Prisma commands:
 
 ```bash
-pnpm --filter @app/web prisma migrate dev -n init
-pnpm --filter @app/web prisma generate
+pnpm prisma migrate dev -n init
+pnpm prisma generate
 ```
+
+The top-level `pnpm prisma` script proxies commands to the `@app/web` package so the CLI picks up `apps/web/prisma/.env` without manually exporting `DATABASE_URL`.
 
 ## Admin Billing CRUD
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "turbo run dev --parallel",
     "dev:infra": "docker compose -f infra/docker-compose.dev.yml up -d",
     "dev:infra:down": "docker compose -f infra/docker-compose.dev.yml down -v",
+    "prisma": "pnpm --filter @app/web exec -- prisma",
     "db:reset": "pnpm --filter @app/web prisma migrate reset --force && pnpm --filter @app/web prisma generate",
     "build": "turbo run build",
     "lint": "turbo run lint",


### PR DESCRIPTION
## Summary
- add a workspace-level `pnpm prisma` script that executes Prisma CLI commands from the `@app/web` package so the schema picks up `DATABASE_URL`
- refresh the documentation to demonstrate the new shortcut and explain how it loads the Prisma `.env`

## Testing
- not run (offline environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4758fa99883279fff1a0347873232