### PR TITLE
Fix Prisma env duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pnpm prisma migrate dev -n init
 pnpm prisma generate
 ```
 
-The top-level `pnpm prisma` script proxies commands to the `@app/web` package so the CLI picks up `apps/web/prisma/.env` without manually exporting `DATABASE_URL`.
+The top-level `pnpm prisma` script proxies commands to the `@app/web` package so Prisma automatically reads `apps/web/.env` without manually exporting `DATABASE_URL`.
 
 ## Admin Billing CRUD
 

--- a/apps/web/prisma/.env
+++ b/apps/web/prisma/.env
@@ -1,3 +1,5 @@
 # Prisma CLI environment variables for @app/web
-# Update the connection string as needed for your local setup.
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"
+#
+# DATABASE_URL is provided via ../.env to avoid duplicate definitions between
+# Prisma's default dotenv locations. Keep this file for future CLI-specific
+# overrides that do not conflict with values in apps/web/.env.


### PR DESCRIPTION
## Summary
- remove the DATABASE_URL definition from apps/web/prisma/.env so Prisma no longer sees conflicting dotenv values
- document that the pnpm prisma helper command loads configuration from apps/web/.env

## Testing
- pnpm --filter @app/web exec -- prisma migrate deploy *(fails in CI environment: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68e478060cb88327b368627dba1eeee6