### PR TITLE
Add committed Prisma env defaults for database URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ dist
 .turbo
 .env*
 !.env.example
+!apps/web/.env
 !apps/web/.env.example
+!apps/web/prisma/.env
 !apps/web/prisma/.env.example
 pnpm-lock.yaml
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ This application uses Prisma with a PostgreSQL database connection.
 
 ## Database configuration
 
-Copy `apps/web/.env.example` to `apps/web/.env` (or export the variable in your shell) and adjust the connection string if needed:
+The repository now includes `apps/web/.env` and `apps/web/prisma/.env` with a default development connection string. Update the
+value if your local database credentials differ.
+
+If you prefer to manage environment variables manually, copy `apps/web/.env.example` to `apps/web/.env` (or export the variable
+in your shell) and adjust the connection string if needed:
 
 ```env
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting"

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,0 +1,2 @@
+# Default development database connection for Prisma CLI and Next.js app
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting"

--- a/apps/web/prisma/.env
+++ b/apps/web/prisma/.env
@@ -1,0 +1,3 @@
+# Prisma CLI picks up DATABASE_URL from this file when running migrations.
+# Keep this in sync with apps/web/.env so local commands work out of the box.
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting"


### PR DESCRIPTION
## Summary
- allow committing the Prisma env files so the CLI has a default DATABASE_URL
- add default database connection strings for the web app and Prisma CLI
- update the setup docs to mention the bundled development env files

## Testing
- ⚠️ `pnpm prisma migrate deploy` *(fails in CI environment when pnpm download is blocked by the proxy, but the DATABASE_URL is now provided via the committed env files)*

------
https://chatgpt.com/codex/tasks/task_e_68e47ee84f808327a4be996a7dde5fc2