### PR TITLE
Fix Prisma schema access error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ This application uses Prisma with a PostgreSQL database connection.
 The repository now includes `apps/web/.env` and `apps/web/prisma/.env` with a default development connection string. Update the
 value if your local database credentials differ.
 
+> **Why the `schema=public` suffix?** Prisma issues migrations inside the specified schema. Explicitly pinning the schema prevents the CLI from falling back to a restricted default (which previously triggered `P1010` permission errors for the `postgres` user during `pnpm prisma migrate deploy`).
+
 If you prefer to manage environment variables manually, copy `apps/web/.env.example` to `apps/web/.env` (or export the variable
 in your shell) and adjust the connection string if needed:
 
 ```env
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"
 ```
 ## Environment variables
 
@@ -26,7 +28,7 @@ The web application reads configuration through a typed loader in `apps/web/lib/
 Example `apps/web/.env.local`:
 
 ```env
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"
 PUBLIC_BASE_URL="http://localhost:3000"
 # WEBHOOK_SHARED_SECRET="dev_secret"
 ```

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,2 +1,2 @@
 # Default development database connection for Prisma CLI and Next.js app
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -24,10 +24,12 @@ The Next.js app relies on `apps/web/lib/env.ts` for typed configuration. Populat
 Example:
 
 ```env
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"
 PUBLIC_BASE_URL="http://localhost:3000"
 # WEBHOOK_SHARED_SECRET="dev_secret"
 ```
+
+> **Tip:** Keeping `schema=public` in the connection string ensures Prisma always applies migrations inside the expected schema. Without it, restricted Postgres roles can surface `P1010` access errors during `prisma migrate deploy`.
 
 Dynamic API handlers (checkout, webhooks, billing) respond with `Cache-Control: no-store`. The pricing API at `/api/pricing` advertises `Cache-Control: public, s-maxage=60, stale-while-revalidate=300` for shared caching.
 


### PR DESCRIPTION
## Summary
- document the need to use the public schema in local Prisma connection strings
- update default DATABASE_URL examples to include the schema parameter
- add troubleshooting context for the previous P1010 permission error

## Testing
- not run (network-restricted environment)


------
https://chatgpt.com/codex/tasks/task_e_68e481be7ec48327953d0912da4887c4