### PR TITLE
Fix Prisma environment variable conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This application uses Prisma with a PostgreSQL database connection.
 
 ## Database configuration
 
-The repository now includes `apps/web/.env` and `apps/web/prisma/.env` with a default development connection string. Update the
+The repository now includes `apps/web/.env` with a default development connection string. Update the
 value if your local database credentials differ.
 
 > **Why the `schema=public` suffix?** Prisma issues migrations inside the specified schema. Explicitly pinning the schema prevents the CLI from falling back to a restricted default (which previously triggered `P1010` permission errors for the `postgres` user during `pnpm prisma migrate deploy`).
@@ -40,7 +40,7 @@ pnpm prisma migrate dev -n init
 pnpm prisma generate
 ```
 
-When running Prisma commands, copy `apps/web/prisma/.env.example` to `apps/web/prisma/.env` (or set `DATABASE_URL` in your environment) so the CLI uses the correct credentials for your database. The top-level `pnpm prisma` script proxies commands to the `@app/web` package, so Prisma automatically loads the `apps/web/prisma/.env` file you create.
+Prisma automatically loads `apps/web/.env`, so you only need to define the connection string in that file (or export `DATABASE_URL` in your shell). The top-level `pnpm prisma` script proxies commands to the `@app/web` package, so the CLI picks up the same configuration that Next.js uses.
 
 ## Admin Billing CRUD
 

--- a/apps/web/prisma/.env
+++ b/apps/web/prisma/.env
@@ -1,2 +1,0 @@
-# Prisma CLI default environment for the web app
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"


### PR DESCRIPTION
## Summary
- remove the duplicate Prisma CLI `.env` file so the generator reads from the shared app configuration
- update the documentation to note that `apps/web/.env` now drives both the app and Prisma commands

## Testing
- pnpm prisma generate *(fails: corepack cannot download pnpm due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e484f3daf083279980cdb0f72b91d0