### PR TITLE
Ensure Prisma scripts load the web env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This application uses Prisma with a PostgreSQL database connection.
 
 ## Database configuration
 
-The repository now includes `apps/web/.env` and `apps/web/prisma/.env` with a default development connection string. Update the
+The repository now includes `apps/web/.env` with a default development connection string. Update the
 value if your local database credentials differ.
 
 > **Why the `schema=public` suffix?** Prisma issues migrations inside the specified schema. Explicitly pinning the schema prevents the CLI from falling back to a restricted default (which previously triggered `P1010` permission errors for the `postgres` user during `pnpm prisma migrate deploy`).
@@ -33,14 +33,17 @@ PUBLIC_BASE_URL="http://localhost:3000"
 # WEBHOOK_SHARED_SECRET="dev_secret"
 ```
 
-After setting the environment variable you can run the Prisma commands:
+After setting the environment variable you can run the Prisma commands. The root `pnpm prisma` helper
+preloads `apps/web/.env` via [`dotenv-cli`](https://github.com/entropitor/dotenv-cli) so every Prisma
+invocation (including `pnpm prisma migrate deploy`) receives the same connection string that the
+Next.js app uses:
 
 ```bash
 pnpm prisma migrate dev -n init
 pnpm prisma generate
 ```
 
-When running Prisma commands, copy `apps/web/prisma/.env.example` to `apps/web/prisma/.env` (or set `DATABASE_URL` in your environment) so the CLI uses the correct credentials for your database. The top-level `pnpm prisma` script proxies commands to the `@app/web` package, so Prisma automatically loads the `apps/web/prisma/.env` file you create.
+Prisma automatically loads `apps/web/.env`, so you only need to define the connection string in that file (or export `DATABASE_URL` in your shell). The top-level `pnpm prisma` script proxies commands to the `@app/web` package, so the CLI picks up the same configuration that Next.js uses.
 
 ## Admin Billing CRUD
 

--- a/apps/web/prisma/.env
+++ b/apps/web/prisma/.env
@@ -1,2 +1,0 @@
-# Prisma CLI default environment for the web app
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dev": "turbo run dev --parallel",
     "dev:infra": "docker compose -f infra/docker-compose.dev.yml up -d",
     "dev:infra:down": "docker compose -f infra/docker-compose.dev.yml down -v",
-    "prisma": "pnpm --filter @app/web exec -- prisma",
-    "db:reset": "pnpm --filter @app/web prisma migrate reset --force && pnpm --filter @app/web prisma generate",
+    "prisma": "dotenv -e apps/web/.env -- pnpm --filter @app/web exec -- prisma",
+    "db:reset": "pnpm prisma migrate reset --force && pnpm prisma generate",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck"
@@ -19,6 +19,7 @@
     "@types/node": "^20.19.17",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
+    "dotenv-cli": "^7.4.2",
     "prisma": "6.16.3",
     "turbo": "^2.0.6",
     "typescript": "^5.6.2"


### PR DESCRIPTION
## Summary
- wrap the root Prisma helper with dotenv-cli so commands load apps/web/.env
- simplify the db:reset helper to reuse the new Prisma wrapper
- document that pnpm prisma now ensures migrate deploy uses the shared connection string

## Testing
- Not run (pnpm cannot be downloaded in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e484f3daf083279980cdb0f72b91d0