### PR TITLE
Add jobs moderation QA coverage and docs

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,4 +1,31 @@
-# Billing Sandbox
+# Web App — Billing & Jobs Sandbox
+
+This package powers both the billing sandbox and the Jobs public/SEO plus admin moderation tooling
+delivered in Sprint 4. Use the steps below to bootstrap a local environment, run automated QA, and
+execute the manual verification checklists referenced in `docs/jobs-handbook.md`.
+
+## Quick start
+
+```bash
+pnpm install
+
+# Copy defaults and adjust DATABASE_URL if required
+cp apps/web/.env.example apps/web/.env.local
+
+pnpm --filter @app/web prisma migrate dev
+pnpm --filter @app/web db:seed
+
+# Launch Next.js (http://localhost:3000)
+pnpm --filter @app/web dev
+
+# QA gates
+pnpm --filter @app/web lint
+pnpm --filter @app/web typecheck
+pnpm --filter @app/web test --coverage
+```
+
+Vitest coverage thresholds ensure the moderation state machine, rate limiting, public listing queries,
+notification dispatcher, cache invalidation, and view debounce helpers stay verified.
 
 ## Environment variables
 
@@ -10,7 +37,7 @@ The Next.js app relies on `apps/web/lib/env.ts` for typed configuration. Populat
 | `PUBLIC_BASE_URL` | ✅ | Absolute origin without a trailing slash (e.g. `http://localhost:3000`). |
 | `WEBHOOK_SHARED_SECRET` | ❌ | Optional sandbox secret; omit locally to bypass signature checks. |
 
-## Sprint 3 — Jobs
+## Sprint 4 — Jobs public & admin flows
 
 - **New Prisma additions**
   - Model: `Job`
@@ -20,6 +47,9 @@ The Next.js app relies on `apps/web/lib/env.ts` for typed configuration. Populat
   - Apply migration: `pnpm --filter @app/web prisma migrate dev`
   - Regenerate client: `pnpm --filter @app/web prisma generate`
 - No new environment variables are required for this phase.
+
+Refer to `docs/jobs-handbook.md` for the moderation UX, notification triggers, cache tags, and
+security rules that back the new jobs experiences.
 
 Example:
 

--- a/apps/web/app/(admin)/admin/jobs/actions.test.ts
+++ b/apps/web/app/(admin)/admin/jobs/actions.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+const getSessionMock = vi.hoisted(() => vi.fn());
+const approveJobAdminMock = vi.hoisted(() => vi.fn());
+const rejectJobAdminMock = vi.hoisted(() => vi.fn());
+const featureJobAdminMock = vi.hoisted(() => vi.fn());
+const suspendJobAdminMock = vi.hoisted(() => vi.fn());
+const closeJobAdminMock = vi.hoisted(() => vi.fn());
+
+const revalidatePathMock = vi.hoisted(() => vi.fn());
+const notFoundMock = vi.hoisted(() => vi.fn(() => {
+  throw new Error("NOT_FOUND");
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getServerAuthSession: getSessionMock,
+}));
+
+vi.mock("@/lib/jobs/admin/approveJob", () => ({
+  approveJobAdmin: approveJobAdminMock,
+}));
+
+vi.mock("@/lib/jobs/admin/rejectJob", () => ({
+  rejectJobAdmin: rejectJobAdminMock,
+}));
+
+vi.mock("@/lib/jobs/admin/featureJob", () => ({
+  featureJobAdmin: featureJobAdminMock,
+}));
+
+vi.mock("@/lib/jobs/admin/suspendJob", () => ({
+  suspendJobAdmin: suspendJobAdminMock,
+}));
+
+vi.mock("@/lib/jobs/admin/closeJobAdmin", () => ({
+  closeJobByAdmin: closeJobAdminMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+}));
+
+describe("admin job server actions", () => {
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    approveJobAdminMock.mockReset();
+    rejectJobAdminMock.mockReset();
+    featureJobAdminMock.mockReset();
+    suspendJobAdminMock.mockReset();
+    closeJobAdminMock.mockReset();
+    revalidatePathMock.mockReset();
+    notFoundMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("denies anonymous users", async () => {
+    getSessionMock.mockResolvedValue(null);
+    const { approveJobAction } = await import("./actions");
+
+    const result = await approveJobAction("job123");
+
+    expect(result).toEqual({ ok: false, error: "NOT_FOUND" });
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+
+  it("denies non-admin users", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user1", role: "USER" } });
+    const { rejectJobAction } = await import("./actions");
+
+    const result = await rejectJobAction("job123", "invalid");
+
+    expect(result).toEqual({ ok: false, error: "NOT_FOUND" });
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+
+  it("validates identifiers before calling admin services", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "admin1", role: "ADMIN" } });
+    const { approveJobAction } = await import("./actions");
+
+    const result = await approveJobAction("invalid-id");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("شناسه");
+    expect(approveJobAdminMock).not.toHaveBeenCalled();
+  });
+
+  it("invokes admin operations when authorized", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "admin1", role: "ADMIN" } });
+    approveJobAdminMock.mockResolvedValue({});
+    const { approveJobAction } = await import("./actions");
+
+    const jobId = "ckuzx0s2c0000u7d2x7v4a5y6";
+    const result = await approveJobAction(jobId);
+
+    expect(result).toEqual({ ok: true });
+    expect(approveJobAdminMock).toHaveBeenCalledWith(jobId, "admin1");
+  });
+
+  it("rate limits feature commands", async () => {
+    vi.useFakeTimers();
+    try {
+      getSessionMock.mockResolvedValue({ user: { id: "admin1", role: "ADMIN" } });
+      featureJobAdminMock.mockResolvedValue({});
+      const { featureJobAction } = await import("./actions");
+      const jobId = "ckuzx0s2c0000u7d2x7v4a5y6";
+
+      for (let i = 0; i < 5; i += 1) {
+        const result = await featureJobAction(jobId, { type: "CLEAR" });
+        expect(result).toEqual({ ok: true });
+      }
+
+      const limited = await featureJobAction(jobId, { type: "CLEAR" });
+      expect(limited.ok).toBe(false);
+      expect(limited.error).toContain("تعداد درخواست‌ها زیاد است");
+
+      vi.advanceTimersByTime(61 * 1000);
+      const reset = await featureJobAction(jobId, { type: "CLEAR" });
+      expect(reset).toEqual({ ok: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/docs/jobs-handbook.md
+++ b/apps/web/docs/jobs-handbook.md
@@ -1,0 +1,130 @@
+# Jobs Moderation & Release Handbook
+
+This handbook captures the operational details for the Jobs public listing, admin moderation flows,
+notification fan-out, caching strategy, and security posture introduced in Sprint 4.
+
+## Admin moderation guide
+
+### Access control
+
+- `/admin/jobs` and `/admin/jobs/[id]` are server components gated by `getServerAuthSession`. Only
+  users with `role === "ADMIN"` reach the page; others trigger `notFound()`.
+- Every server action re-fetches the session to enforce defense-in-depth. Tests under
+  `app/(admin)/admin/jobs/actions.test.ts` assert that anonymous and non-admin callers receive a
+  denial response.
+
+### Actions & limits
+
+| Action | Allowed from | Result | Notes |
+| --- | --- | --- | --- |
+| Approve | Pending / Rejected / Suspended | Sets `moderation=APPROVED` | Emits `MODERATION_APPROVED` notification and revalidates list/detail caches. |
+| Reject | Pending / Approved / Suspended | Sets `moderation=REJECTED` | Optional note trimmed to 500 chars. Sends `MODERATION_REJECTED`. |
+| Suspend | Pending / Approved / Rejected | Sets `moderation=SUSPENDED` | Optional note stored; notification uses action=`SUSPENDED`. |
+| Feature | Approved jobs | Updates `featuredUntil` | Preset (7/14/30 days) or custom date capped at 60 days. Extends from existing feature when still active. |
+| Clear feature | Featured jobs | Sets `featuredUntil=null` | Emits `MODERATION_PENDING` with action=`UNFEATURED`. |
+| Close | Any status except `CLOSED` | Sets `status=CLOSED` | Stops public visibility and triggers `MODERATION_PENDING` with action=`CLOSED`. |
+
+Additional rules:
+
+- Custom feature requests normalize to 23:59:59 of the selected day and reject past dates or
+  schedules beyond 60 days.
+- Feature/unfeature commands are rate limited to **5 operations per minute per admin**. Surplus
+  requests return a localized error advising the admin to retry later. The limiter is tested to ensure
+  it resets after the window.
+- Every moderation change writes a `jobModerationEvent` row containing the admin id, action, and
+  optional note to maintain an auditable history.
+- Actions call `revalidateJobRelatedPaths` which revalidates all relevant cache tags plus the author
+  dashboard view.
+
+## Notifications reference
+
+All job-related notifications fan out through `notifyOnce`, which deduplicates events by user, type,
+body/payload hash within a 10 minute window and records dispatch instrumentation.
+
+| Scenario | Event helper | NotificationType | Channels | Dedupe key |
+| --- | --- | --- | --- | --- |
+| Approve | `emitJobApproved` | `MODERATION_APPROVED` | In-app | `MODERATION_APPROVED:job:<jobId>:<jobStatus>` |
+| Reject | `emitJobRejected` | `MODERATION_REJECTED` | In-app | `MODERATION_REJECTED:job:<jobId>:<note>` |
+| Suspend | `emitJobPending` (`action="SUSPENDED"`) | `MODERATION_PENDING` | In-app | `MODERATION_PENDING:job:<jobId>:SUSPENDED:<note>` |
+| Pending (manual revert) | `emitJobPending` (`action="PENDING"`) | `MODERATION_PENDING` | In-app | `MODERATION_PENDING:job:<jobId>:PENDING:<note>` |
+| Feature | `emitJobFeatured` | `MODERATION_PENDING` | In-app | `MODERATION_PENDING:job:<jobId>:FEATURED:<iso>` |
+| Unfeature | `emitJobUnfeatured` | `MODERATION_PENDING` | In-app | `MODERATION_PENDING:job:<jobId>:UNFEATURED` |
+| Close | `emitJobClosed` | `MODERATION_PENDING` | In-app | `MODERATION_PENDING:job:<jobId>:CLOSED` |
+
+Email delivery is optional. `notifyOnce` automatically adds the e-mail channel when
+`isEmailConfigured()` returns `true`. Otherwise only in-app notifications are persisted. Each dispatch
+emits an instrumentation event for observability; tests validate both dedupe and observer hooks.
+
+## Caching & revalidation
+
+### Tag taxonomy
+
+| Tag | Description |
+| --- | --- |
+| `cities` | Location cache for dropdowns. |
+| `jobs:filters` | Distinct category & pay-type filters. |
+| `jobs:list` | Base public listing. |
+| `jobs:list:city:<cityId>` | City-specific listing facet. |
+| `jobs:list:category:<category>` | Category facet. |
+| `jobs:list:remote:<0/1>` | Remote filter facet. |
+| `jobs:list:payType:<type>` | Pay-type facet. |
+| `jobs:list:sort:<sort>` | Sort option facet (`newest`, `featured`, `expiring`). |
+| `job:<id>` | Individual job detail. |
+| `job:<id>:views` | Debounced view counter. |
+
+`getPublicJobs`, `getPublicJobById`, and `getPublicJobFilters` use `unstable_cache` with the above
+facets and TTLs (`CACHE_REVALIDATE`). Admin actions call `revalidateJobRelatedPaths(jobId)` which:
+
+1. Fetches the job to gather all applicable tags (city/category/payType/remote + sort tags).
+2. Revalidates each tag plus the filters aggregate via `revalidateTag`.
+3. Revalidates `/dashboard/jobs` to refresh author/admin dashboards.
+
+Tests in `lib/jobs/publicQueries.test.ts` and `lib/jobs/revalidate.test.ts` cover the tag selection and
+revalidation behavior to prevent regressions.
+
+## Security notes
+
+- **Authorization** – Page-level guards plus server-action checks ensure only admins can moderate
+  jobs. Non-admins trigger `notFound()` and receive localized error responses.
+- **Validation** – All inputs pass through Zod schemas (`cuid` ids, preset/custom feature commands,
+  optional notes capped at 500 characters). Invalid data surfaces localized errors to the UI.
+- **Sanitized rendering** – Public job pages render plain text descriptions with `whitespace-pre-line`;
+  admin-only fields and notes never leak into public responses. JSON-LD remains sanitized through the
+  existing SEO helpers.
+- **Rate limiting** – Feature commands are throttled; job view increments use an httpOnly cookie with a
+  30-minute debounce window (tests verify the cookie guard).
+- **Secrets** – No secrets are checked into the repo. Email delivery is optional; in-app notifications
+  function regardless of SMTP configuration.
+
+## Release notes & post-merge checklist
+
+### Versioning
+
+- Bump `@app/web` version to `0.1.0` for the Jobs release.
+- Tag the repository as `jobs-sprint4` (example) after merging and use the changelog below in the
+  release description.
+
+### Changelog highlights
+
+- Added admin jobs moderation dashboard with approve/reject/suspend/feature/close actions.
+- Implemented public `/jobs` listing filters, pagination, and JSON-LD metadata.
+- Added notification fan-out for all moderation outcomes with dedupe + instrumentation.
+- Implemented cache tag taxonomy with tag-based revalidation after admin changes.
+- Added rate limiting to feature/unfeature commands and coverage-gated automated tests.
+
+### Post-merge verification
+
+1. Run CI: `pnpm --filter @app/web lint`, `typecheck`, `test --coverage`, and `next build`.
+2. Deploy to staging and smoke test:
+   - `/jobs` lists only `PUBLISHED` + `APPROVED` jobs; JSON-LD present.
+   - Approve a pending job in `/admin/jobs` → listing reflects change without refresh, notification
+     appears for the owner.
+   - Reject a job with a note → note visible in notification center only.
+   - Feature a job (preset + custom) → badge visible until expiration.
+   - Close a job → disappears from public lists; owner sees closed status in dashboard.
+3. Validate accessibility with automated tooling (Lighthouse or axe) to ensure headings, button text,
+   and focus order remain correct on `/jobs` and `/admin/jobs`.
+4. Confirm `revalidateTag` instrumentation in logs and that notification dispatch observer captures
+   events without errors.
+
+For additional manual test scripts see the billing and job flow checklist in `apps/web/README.md`.

--- a/apps/web/lib/jobs/admin/flows.test.ts
+++ b/apps/web/lib/jobs/admin/flows.test.ts
@@ -1,0 +1,222 @@
+import { JobModeration, JobStatus } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPrisma = vi.hoisted(() => ({
+  job: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  jobModerationEvent: {
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(),
+}));
+
+const mockRevalidate = vi.hoisted(() => ({
+  revalidateJobRelatedPaths: vi.fn(),
+}));
+
+const mockNotifications = vi.hoisted(() => ({
+  emitJobApproved: vi.fn(),
+  emitJobRejected: vi.fn(),
+  emitJobPending: vi.fn(),
+  emitJobFeatured: vi.fn(),
+  emitJobUnfeatured: vi.fn(),
+  emitJobClosed: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock("@/lib/jobs/revalidate", () => mockRevalidate);
+
+vi.mock("@/lib/notifications/events", () => mockNotifications);
+
+const defaultJob = {
+  id: "job_1",
+  userId: "user_1",
+  title: "Backend Engineer",
+  status: JobStatus.PUBLISHED,
+  moderation: JobModeration.PENDING,
+  featuredUntil: null as Date | null,
+  createdAt: new Date("2024-01-10T00:00:00.000Z"),
+};
+
+function setupPrisma(job = defaultJob) {
+  mockPrisma.job.findUnique.mockResolvedValue(job);
+  mockPrisma.job.update.mockResolvedValue(job);
+  mockPrisma.jobModerationEvent.create.mockResolvedValue({
+    id: "event_1",
+    jobId: job.id,
+  });
+  mockPrisma.$transaction.mockImplementation(async (operations: unknown[]) => {
+    const results: unknown[] = [];
+    for (const operation of operations as Promise<unknown>[]) {
+      results.push(await operation);
+    }
+    return results;
+  });
+}
+
+describe("job admin flows", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-02-01T12:00:00.000Z"));
+    setupPrisma();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  it("approves a pending job and emits notification", async () => {
+    const { approveJobAdmin } = await import("./approveJob");
+    const updated = { ...defaultJob, moderation: JobModeration.APPROVED };
+    mockPrisma.job.update.mockResolvedValueOnce(updated);
+
+    const result = await approveJobAdmin(defaultJob.id, "admin_1");
+
+    expect(mockPrisma.job.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: defaultJob.id },
+        data: { moderation: JobModeration.APPROVED },
+      }),
+    );
+    expect(mockPrisma.jobModerationEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: "APPROVE", adminId: "admin_1" }),
+      }),
+    );
+    expect(mockRevalidate.revalidateJobRelatedPaths).toHaveBeenCalledWith(defaultJob.id);
+    expect(mockNotifications.emitJobApproved).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: defaultJob.id, userId: defaultJob.userId }),
+    );
+    expect(result).toEqual(updated);
+  });
+
+  it("rejects a job with a trimmed note", async () => {
+    const { rejectJobAdmin } = await import("./rejectJob");
+    const updated = { ...defaultJob, moderation: JobModeration.REJECTED };
+    mockPrisma.job.update.mockResolvedValueOnce(updated);
+
+    await rejectJobAdmin(defaultJob.id, "admin_1", "  invalid details  ");
+
+    expect(mockPrisma.jobModerationEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "REJECT",
+          note: "invalid details",
+        }),
+      }),
+    );
+    expect(mockNotifications.emitJobRejected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: defaultJob.id,
+        note: "invalid details",
+      }),
+    );
+  });
+
+  it("suspends an approved job and preserves note", async () => {
+    setupPrisma({ ...defaultJob, moderation: JobModeration.APPROVED });
+    const { suspendJobAdmin } = await import("./suspendJob");
+    const updated = { ...defaultJob, moderation: JobModeration.SUSPENDED };
+    mockPrisma.job.update.mockResolvedValueOnce(updated);
+
+    await suspendJobAdmin(defaultJob.id, "admin_1", "missing license");
+
+    expect(mockNotifications.emitJobPending).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "SUSPENDED", note: "missing license" }),
+    );
+  });
+
+  it("clears an existing suspension without duplicate writes", async () => {
+    setupPrisma({ ...defaultJob, moderation: JobModeration.SUSPENDED });
+    const { suspendJobAdmin } = await import("./suspendJob");
+
+    await suspendJobAdmin(defaultJob.id, "admin_1");
+
+    expect(mockPrisma.job.update).not.toHaveBeenCalled();
+  });
+
+  it("features a job for preset days", async () => {
+    setupPrisma({
+      ...defaultJob,
+      moderation: JobModeration.APPROVED,
+      featuredUntil: null,
+    });
+    const { featureJobAdmin } = await import("./featureJob");
+    const updated = {
+      ...defaultJob,
+      moderation: JobModeration.APPROVED,
+      featuredUntil: new Date("2024-02-08T12:00:00.000Z"),
+    };
+    mockPrisma.job.update.mockResolvedValueOnce(updated);
+
+    const result = await featureJobAdmin(defaultJob.id, "admin_1", { type: "PRESET", days: 7 });
+
+    expect(mockNotifications.emitJobFeatured).toHaveBeenCalledWith(
+      expect.objectContaining({ featuredUntil: updated.featuredUntil }),
+    );
+    expect(result).toEqual(updated);
+  });
+
+  it("rejects custom feature ranges beyond 60 days", async () => {
+    setupPrisma({ ...defaultJob, moderation: JobModeration.APPROVED });
+    const { featureJobAdmin } = await import("./featureJob");
+
+    await expect(
+      featureJobAdmin(defaultJob.id, "admin_1", {
+        type: "CUSTOM",
+        until: new Date("2024-04-10T00:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_FEATURE_SCHEDULE" });
+  });
+
+  it("unfeatures when clearing active feature", async () => {
+    setupPrisma({
+      ...defaultJob,
+      moderation: JobModeration.APPROVED,
+      featuredUntil: new Date("2024-02-10T00:00:00.000Z"),
+    });
+    const { featureJobAdmin } = await import("./featureJob");
+    mockPrisma.job.update.mockResolvedValueOnce({
+      ...defaultJob,
+      featuredUntil: null,
+    });
+
+    await featureJobAdmin(defaultJob.id, "admin_1", { type: "CLEAR" });
+
+    expect(mockNotifications.emitJobUnfeatured).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: defaultJob.id }),
+    );
+  });
+
+  it("closes an open job", async () => {
+    const { closeJobByAdmin } = await import("./closeJobAdmin");
+    const updated = { ...defaultJob, status: JobStatus.CLOSED };
+    mockPrisma.job.update.mockResolvedValueOnce(updated);
+
+    await closeJobByAdmin(defaultJob.id, "admin_1");
+
+    expect(mockPrisma.job.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: JobStatus.CLOSED } }),
+    );
+    expect(mockNotifications.emitJobClosed).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: defaultJob.id }),
+    );
+  });
+
+  it("skips redundant close operations", async () => {
+    setupPrisma({ ...defaultJob, status: JobStatus.CLOSED });
+    const { closeJobByAdmin } = await import("./closeJobAdmin");
+
+    await closeJobByAdmin(defaultJob.id, "admin_1");
+
+    expect(mockPrisma.job.update).not.toHaveBeenCalled();
+    expect(mockNotifications.emitJobClosed).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/jobs/publicQueries.test.ts
+++ b/apps/web/lib/jobs/publicQueries.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+import { CACHE_TAGS } from "@/lib/cache/config";
+import { PUBLIC_JOBS_PAGE_SIZE } from "@/lib/jobs/constants";
+
+const mockPrisma = vi.hoisted(() => ({
+  job: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+  },
+}));
+
+const cacheCalls: { keys: string[]; options?: unknown }[] = [];
+
+const mockCache = vi.hoisted(() => ({
+  unstable_cache: vi.fn((resolver: (...args: unknown[]) => unknown, keys: string[], options?: unknown) => {
+    cacheCalls.push({ keys, options });
+    return resolver;
+  }),
+}));
+
+vi.mock("next/cache", () => mockCache);
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+describe("public job queries", () => {
+  beforeEach(() => {
+    cacheCalls.length = 0;
+    mockPrisma.job.findMany.mockResolvedValue([]);
+    mockPrisma.job.count.mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("enforces approved & published visibility", async () => {
+    const { getPublicJobs, buildPublicWhere } = await import("./publicQueries");
+    await getPublicJobs({ city: "tehran", category: "ENGINEERING", remote: true, payType: "FULL_TIME" });
+
+    const where = buildPublicWhere({ city: "tehran", category: "ENGINEERING", remote: true, payType: "FULL_TIME" });
+
+    expect(where).toMatchObject({
+      status: "PUBLISHED",
+      moderation: "APPROVED",
+      cityId: "tehran",
+      category: "ENGINEERING",
+      remote: true,
+      payType: "FULL_TIME",
+    });
+
+    expect(mockPrisma.job.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 0,
+        take: PUBLIC_JOBS_PAGE_SIZE,
+      }),
+    );
+  });
+
+  it("supports pagination & sort specific cache tags", async () => {
+    const { getPublicJobs, buildPublicOrderBy } = await import("./publicQueries");
+
+    mockPrisma.job.findMany.mockResolvedValue([
+      { id: "job1" },
+    ]);
+    mockPrisma.job.count.mockResolvedValue(25);
+
+    const result = await getPublicJobs({ sort: "featured", page: 2, remote: true });
+
+    expect(result.page).toBe(2);
+    expect(result.totalPages).toBeGreaterThan(1);
+
+    expect(mockPrisma.job.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [
+          { featuredUntil: { sort: "desc", nulls: "last" } },
+          { createdAt: "desc" },
+        ],
+        skip: PUBLIC_JOBS_PAGE_SIZE,
+      }),
+    );
+
+    expect(buildPublicOrderBy("expiring")).toEqual([
+      { featuredUntil: { sort: "asc", nulls: "last" } },
+      { createdAt: "desc" },
+    ]);
+
+    expect(cacheCalls[0]?.options).toMatchObject({
+      tags: expect.arrayContaining([
+        CACHE_TAGS.jobsList,
+        CACHE_TAGS.jobsListRemote(true),
+        CACHE_TAGS.jobsListSort("featured"),
+      ]),
+    });
+  });
+
+  it("collects filters with shared cache tag", async () => {
+    const { getPublicJobFilters } = await import("./publicQueries");
+
+    mockPrisma.job.findMany
+      .mockResolvedValueOnce([
+        { category: "DESIGN" },
+        { category: "ENGINEERING" },
+      ])
+      .mockResolvedValueOnce([
+        { payType: "FULL_TIME" },
+        { payType: "PART_TIME" },
+      ]);
+
+    const filters = await getPublicJobFilters();
+
+    expect(filters.categories).toEqual(["DESIGN", "ENGINEERING"]);
+    expect(filters.payTypes).toEqual(["FULL_TIME", "PART_TIME"]);
+
+    expect(cacheCalls.pop()?.options).toMatchObject({
+      tags: expect.arrayContaining([CACHE_TAGS.jobsFilters, CACHE_TAGS.jobsList]),
+    });
+  });
+});

--- a/apps/web/lib/jobs/revalidate.test.ts
+++ b/apps/web/lib/jobs/revalidate.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CACHE_TAGS } from "@/lib/cache/config";
+
+const prismaMock = vi.hoisted(() => ({
+  job: {
+    findUnique: vi.fn(),
+  },
+}));
+
+const revalidateTagMock = vi.hoisted(() => vi.fn());
+const revalidatePathMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("next/cache", () => ({
+  revalidateTag: revalidateTagMock,
+  revalidatePath: revalidatePathMock,
+}));
+
+describe("job revalidation", () => {
+  beforeEach(() => {
+    prismaMock.job.findUnique.mockResolvedValue({
+      cityId: "tehran",
+      category: "ENGINEERING",
+      remote: true,
+      payType: "FULL_TIME",
+    });
+    revalidateTagMock.mockClear();
+    revalidatePathMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns all relevant cache tags", async () => {
+    const { getJobTags } = await import("./revalidate");
+
+    const tags = await getJobTags("job1");
+
+    expect(tags).toEqual(
+      expect.arrayContaining([
+        CACHE_TAGS.jobDetail("job1"),
+        CACHE_TAGS.jobsListCity("tehran"),
+        CACHE_TAGS.jobsListCategory("ENGINEERING"),
+        CACHE_TAGS.jobsListRemote(true),
+        CACHE_TAGS.jobsListPayType("FULL_TIME"),
+      ]),
+    );
+  });
+
+  it("revalidates tags and dashboard path", async () => {
+    const { revalidateJobRelatedPaths } = await import("./revalidate");
+
+    await revalidateJobRelatedPaths("job1");
+
+    expect(revalidateTagMock).toHaveBeenCalled();
+    expect(revalidatePathMock).toHaveBeenCalledWith("/dashboard/jobs");
+  });
+});

--- a/apps/web/lib/jobs/views.test.ts
+++ b/apps/web/lib/jobs/views.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cookieStore = {
+  value: new Map<string, string>(),
+  get: vi.fn((name: string) => {
+    const value = cookieStore.value.get(name);
+    return value ? { name, value } : undefined;
+  }),
+  set: vi.fn(({ name, value }: { name: string; value: string }) => {
+    cookieStore.value.set(name, value);
+  }),
+};
+
+const prismaMock = {
+  job: {
+    update: vi.fn().mockResolvedValue(undefined),
+  },
+};
+
+vi.mock("next/headers", () => ({
+  cookies: () => cookieStore,
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+describe("incrementJobViews", () => {
+  beforeEach(() => {
+    cookieStore.value.clear();
+    cookieStore.get.mockClear();
+    cookieStore.set.mockClear();
+    prismaMock.job.update.mockClear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-03-01T10:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("debounces repeated views within 30 minutes", async () => {
+    const { incrementJobViews } = await import("./views");
+
+    await incrementJobViews("job123");
+    await incrementJobViews("job123");
+
+    expect(prismaMock.job.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("increments again after debounce window", async () => {
+    const { incrementJobViews } = await import("./views");
+
+    await incrementJobViews("job123");
+    vi.advanceTimersByTime(31 * 60 * 1000);
+    await incrementJobViews("job123");
+
+    expect(prismaMock.job.update).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/notifications/dispatcher.test.ts
+++ b/apps/web/lib/notifications/dispatcher.test.ts
@@ -1,0 +1,112 @@
+import { NotificationChannel, NotificationType } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  notification: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+const emailMock = vi.hoisted(() => ({
+  isEmailConfigured: vi.fn(() => false),
+  sendEmail: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+vi.mock("./email", () => emailMock);
+
+describe("notification dispatcher", () => {
+  beforeEach(() => {
+    prismaMock.notification.findFirst.mockReset();
+    prismaMock.notification.create.mockReset();
+    emailMock.isEmailConfigured.mockReturnValue(false);
+    emailMock.sendEmail.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-03-10T09:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it("stores an in-app notification and emits instrumentation", async () => {
+    const { notifyOnce, setNotificationDispatchObserver } = await import("./dispatcher");
+
+    prismaMock.notification.findFirst.mockResolvedValue(null);
+    prismaMock.notification.create.mockResolvedValue({ id: "n1" });
+
+    const events: string[] = [];
+    setNotificationDispatchObserver((event) => {
+      events.push(event.status);
+      expect(event.dedupeHash).toMatch(/[a-f0-9]{64}/);
+      expect(event.channels).toEqual([NotificationChannel.IN_APP]);
+    });
+
+    await notifyOnce({
+      userId: "user1",
+      type: NotificationType.MODERATION_APPROVED,
+      title: "Approved",
+      body: "Your job is approved",
+      payload: { context: "job", jobId: "job1" },
+    });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user1",
+          channel: NotificationChannel.IN_APP,
+        }),
+      }),
+    );
+    expect(events).toEqual(["delivered"]);
+  });
+
+  it("deduplicates notifications within the time window", async () => {
+    const { notifyOnce } = await import("./dispatcher");
+
+    prismaMock.notification.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "existing" });
+
+    prismaMock.notification.create.mockResolvedValue({ id: "new" });
+
+    await notifyOnce({
+      userId: "user2",
+      type: NotificationType.MODERATION_PENDING,
+      title: "Pending",
+      body: "Job pending",
+      payload: { context: "job", jobId: "job2" },
+    });
+
+    await notifyOnce({
+      userId: "user2",
+      type: NotificationType.MODERATION_PENDING,
+      title: "Pending",
+      body: "Job pending",
+      payload: { context: "job", jobId: "job2" },
+    });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends email when configured", async () => {
+    const { notifyOnce } = await import("./dispatcher");
+
+    prismaMock.notification.findFirst.mockResolvedValue(null);
+    prismaMock.notification.create.mockResolvedValue({ id: "n2" });
+    emailMock.isEmailConfigured.mockReturnValue(true);
+
+    await notifyOnce({
+      userId: "user3",
+      type: NotificationType.MODERATION_PENDING,
+      title: "Pending",
+      body: "Job pending",
+      channels: [NotificationChannel.IN_APP, NotificationChannel.EMAIL],
+    });
+
+    expect(emailMock.sendEmail).toHaveBeenCalledWith("user3", "Pending", "Job pending");
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@app/web",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "prisma": {
     "schema": "prisma/schema.prisma",

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -9,6 +9,16 @@ export default defineConfig({
     environment: "node",
     globals: true,
     include: ["lib/**/*.test.{ts,tsx}", "**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      thresholds: {
+        statements: 0.65,
+        branches: 0.55,
+        functions: 0.6,
+        lines: 0.65,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add rate limiting and additional error handling to admin job server actions while hardening role checks
- expand QA coverage for jobs moderation flows, public listings, notifications, cache invalidation, and view debounce logic
- document sprint 4 jobs workflows, update quick-start guides, and bump @app/web to v0.1.0 with coverage thresholds

## Testing
- `pnpm --filter @app/web test --coverage` *(fails: registry proxy blocks pnpm download in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e48c4539688327a195c1e8945d82a7