### PR TITLE
Fix admin job tests type safety issues

### DIFF
--- a/apps/web/app/(admin)/admin/jobs/actions.test.ts
+++ b/apps/web/app/(admin)/admin/jobs/actions.test.ts
@@ -87,6 +87,9 @@ describe("admin job server actions", () => {
     const result = await approveJobAction("invalid-id");
 
     expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected action to fail validation");
+    }
     expect(result.error).toContain("شناسه");
     expect(approveJobAdminMock).not.toHaveBeenCalled();
   });
@@ -118,6 +121,9 @@ describe("admin job server actions", () => {
 
       const limited = await featureJobAction(jobId, { type: "CLEAR" });
       expect(limited.ok).toBe(false);
+      if (limited.ok) {
+        throw new Error("Expected rate limit to block feature command");
+      }
       expect(limited.error).toContain("تعداد درخواست‌ها زیاد است");
 
       vi.advanceTimersByTime(61 * 1000);

--- a/apps/web/lib/jobs/admin/flows.test.ts
+++ b/apps/web/lib/jobs/admin/flows.test.ts
@@ -1,6 +1,16 @@
 import { JobModeration, JobStatus } from "@prisma/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+type TestJob = {
+  id: string;
+  userId: string;
+  title: string;
+  status: JobStatus;
+  moderation: JobModeration;
+  featuredUntil: Date | null;
+  createdAt: Date;
+};
+
 const mockPrisma = vi.hoisted(() => ({
   job: {
     findUnique: vi.fn(),
@@ -33,7 +43,7 @@ vi.mock("@/lib/jobs/revalidate", () => mockRevalidate);
 
 vi.mock("@/lib/notifications/events", () => mockNotifications);
 
-const defaultJob = {
+const defaultJob: TestJob = {
   id: "job_1",
   userId: "user_1",
   title: "Backend Engineer",
@@ -43,7 +53,7 @@ const defaultJob = {
   createdAt: new Date("2024-01-10T00:00:00.000Z"),
 };
 
-function setupPrisma(job = defaultJob) {
+function setupPrisma(job: TestJob = defaultJob) {
   mockPrisma.job.findUnique.mockResolvedValue(job);
   mockPrisma.job.update.mockResolvedValue(job);
   mockPrisma.jobModerationEvent.create.mockResolvedValue({


### PR DESCRIPTION
## Summary
- guard assertions on admin job action results so tests access error details safely
- widen the mocked job data type in admin flow tests to allow moderation and status transitions

## Testing
- pnpm --filter @app/web typecheck *(fails: network request blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e48f68a4408327ad0f2c0d3999df80