### PR TITLE
Use explicit TCP host for local Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you prefer to manage environment variables manually, copy `apps/web/.env.exam
 needed:
 
 ```env
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/casting?schema=public"
 ```
 ## Environment variables
 
@@ -57,7 +57,7 @@ The web application reads configuration through a typed loader in `apps/web/lib/
 Example `apps/web/.env.local`:
 
 ```env
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/casting?schema=public"
 PUBLIC_BASE_URL="http://localhost:3000"
 # WEBHOOK_SHARED_SECRET="dev_secret"
 ```

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,2 +1,2 @@
 # Default development database connection for Prisma CLI and Next.js app
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/casting?schema=public"

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and update the values as needed.
 
 # Database connection used by Prisma and the app
-DATABASE_URL="postgresql://user:password@localhost:5432/casting?schema=public"
+DATABASE_URL="postgresql://user:password@127.0.0.1:5432/casting?schema=public"
 
 # Secrets for NextAuth. Replace with a secure value in real environments.
 NEXTAUTH_SECRET="please-change-me"

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -54,7 +54,7 @@ security rules that back the new jobs experiences.
 Example:
 
 ```env
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/casting?schema=public"
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/casting?schema=public"
 PUBLIC_BASE_URL="http://localhost:3000"
 # WEBHOOK_SHARED_SECRET="dev_secret"
 ```


### PR DESCRIPTION
## Summary
- update the default DATABASE_URL examples to use 127.0.0.1 so Prisma connects over TCP
- align the checked-in .env defaults with the documentation to prevent local P1010 access errors

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e491242dc4832782d1945115816f3a