### PR TITLE
Ensure Prisma client enforces public schema usage

### DIFF
--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,17 +1,54 @@
 import { PrismaClient } from "@prisma/client";
 
+import { env } from "@/lib/env";
 
 type GlobalWithPrisma = typeof globalThis & {
- prisma?: PrismaClient;};
-
+  prisma?: PrismaClient;
+};
 
 const globalForPrisma = globalThis as GlobalWithPrisma;
 
+function resolveDatabaseUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const schema = parsed.searchParams.get("schema");
+
+    if (!schema || schema.trim().length === 0) {
+      parsed.searchParams.set("schema", "public");
+
+      if (process.env.NODE_ENV !== "test") {
+        console.warn(
+          "[prisma] DATABASE_URL missing schema parameter. Defaulting to \"public\".",
+        );
+      }
+
+      return parsed.toString();
+    }
+
+    return url;
+  } catch (error) {
+    console.warn(
+      "[prisma] Failed to parse DATABASE_URL. Falling back to the raw value.",
+      error instanceof Error ? error.message : error,
+    );
+    return url;
+  }
+}
+
+const databaseUrl = resolveDatabaseUrl(env.DATABASE_URL);
+
 const createClient = () => {
-  return new PrismaClient();
+  return new PrismaClient({
+    datasources: {
+      db: {
+        url: databaseUrl,
+      },
+    },
+  });
 };
 
 export const prisma: PrismaClient = globalForPrisma.prisma ?? createClient();
+
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;
 }

--- a/apps/web/lib/prisma.ts
+++ b/apps/web/lib/prisma.ts
@@ -1,11 +1,1 @@
-import { PrismaClient } from "@prisma/client";
-
-const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined;
-};
-
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
-
-if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
-}
+export { prisma } from "@/lib/db";


### PR DESCRIPTION
## Summary
- normalize the Prisma connection string to append the public schema when it is missing
- reuse the shared Prisma client everywhere so NextAuth picks up the normalized URL

## Testing
- not run (network access for pnpm is restricted in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e5503cab94832793412ebd15435668