### PR TITLE
refactor: inline env loading for prisma cli

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,7 +50,6 @@
     "@types/react": "^18.3.4",
     "@types/react-dom": "^18.3.0",
     "autoprefixer": "^10.4.19",
-    "dotenv": "^16.6.1",
     "eslint": "^8.57.0",
     "eslint-config-next": "15.0.0-canary.87",
     "postcss": "^8.4.38",

--- a/apps/web/scripts/prisma-cli.ts
+++ b/apps/web/scripts/prisma-cli.ts
@@ -1,10 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
-
-import dotenv from "dotenv";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const appRoot = resolve(__dirname, "..", "");
@@ -15,9 +13,57 @@ const envFiles: Array<{ path: string; override: boolean }> = [
   { path: resolve(appRoot, "prisma/.env"), override: true },
 ];
 
+function parseEnvFile(contents: string): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const match = line.match(/^([\w.-]+)\s*=\s*(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    const [, key, rawValue] = match;
+    let value = rawValue ?? "";
+
+    if (!value.startsWith("\"") && !value.startsWith("'")) {
+      value = value.replace(/\s+#.*$/, "").trim();
+    }
+
+    if (
+      (value.startsWith("\"") && value.endsWith("\"")) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    value = value.replace(/\\n/g, "\n").replace(/\\r/g, "\r");
+
+    env[key] = value;
+  }
+
+  return env;
+}
+
+function loadEnvFile(path: string, override: boolean) {
+  const contents = readFileSync(path, "utf8");
+  const values = parseEnvFile(contents);
+
+  for (const [key, value] of Object.entries(values)) {
+    if (override || process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
 for (const { path, override } of envFiles) {
   if (existsSync(path)) {
-    dotenv.config({ path, override });
+    loadEnvFile(path, override);
   }
 }
 


### PR DESCRIPTION
## Summary
- inline environment file parsing inside the Prisma CLI wrapper so it no longer depends on `dotenv`
- remove the unused `dotenv` development dependency from the web application package

## Testing
- ./node_modules/.bin/tsc --project apps/web/tsconfig.json --noEmit *(fails: existing type errors unrelated to the Prisma CLI script)*

------
https://chatgpt.com/codex/tasks/task_e_68e55eb960048327b94068a83c1aadf7