### PR TITLE
Fix job detail date formatting for string timestamps

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -11,6 +11,34 @@ import { buildJobDetailMetadata, buildJobPostingJsonLd, getJobOrganizationName }
 import { incrementJobViews } from "@/lib/jobs/views";
 import { buildAbsoluteUrl } from "@/lib/url";
 
+function coerceDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+
+    if (!Number.isNaN(date.getTime())) {
+      return date;
+    }
+  }
+
+  return null;
+}
+
+function formatPersianDate(value: unknown): string | null {
+  const date = coerceDate(value);
+
+  if (!date) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("fa-IR", {
+    dateStyle: "medium",
+  }).format(date);
+}
+
 function formatCurrency(amount: number, currency: string): string {
   try {
     return new Intl.NumberFormat("fa-IR", {
@@ -95,9 +123,7 @@ export default async function JobDetailPage({
     cityName,
     url: buildAbsoluteUrl(`/jobs/${job.id}`),
   });
-  const postedAt = new Intl.DateTimeFormat("fa-IR", {
-    dateStyle: "medium",
-  }).format(job.createdAt);
+  const postedAt = formatPersianDate(job.createdAt) ?? "—";
 
   const profileLink = job.user.profile
     ? { pathname: "/profiles/[id]", query: { id: job.user.profile.id } }


### PR DESCRIPTION
## Summary
- coerce job dates before formatting to handle both Date objects and string timestamps
- provide a fallback label when the posted date cannot be parsed

## Testing
- pnpm --filter @app/web lint *(fails: unable to download pnpm due to registry proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e5696ebc2883278c9218c625c36105