### PR TITLE
Fix @app/web typecheck configuration and pay type guard

### DIFF
--- a/apps/web/lib/url/normalizeSearchParams.ts
+++ b/apps/web/lib/url/normalizeSearchParams.ts
@@ -16,11 +16,9 @@ type InputRecord = Record<string, string | string[] | undefined>;
 type Input = URLSearchParams | InputRecord;
 
 const ALLOWED_GENDERS = new Set<NormalizedSearchParams["gender"]>(["male", "female", "other"]);
-const ALLOWED_PAY_TYPES = new Set<NonNullable<NormalizedSearchParams["payType"]>>([
-  "paid",
-  "unpaid",
-  "negotiable",
-]);
+const PAY_TYPES = ["paid", "unpaid", "negotiable"] as const;
+type PayType = (typeof PAY_TYPES)[number];
+const ALLOWED_PAY_TYPES = new Set<string>(PAY_TYPES);
 
 const BOOLEAN_TRUE_FALSE = new Set(["true", "false"]);
 
@@ -52,8 +50,8 @@ export function normalizeSearchParams(input: Input): NormalizedSearchParams {
   assignString(normalized, "category", values.get("category"));
 
   const payType = getFirst(values.get("payType"));
-  if (payType && ALLOWED_PAY_TYPES.has(payType as NormalizedSearchParams["payType"])) {
-    normalized.payType = payType as NormalizedSearchParams["payType"];
+  if (isAllowedPayType(payType)) {
+    normalized.payType = payType;
   }
 
   assignBooleanString(normalized, "featured", values.get("featured"));
@@ -144,6 +142,10 @@ function buildStringArray(values: string[] | undefined): string[] {
   }
 
   return parts;
+}
+
+function isAllowedPayType(value: string | undefined): value is PayType {
+  return value !== undefined && ALLOWED_PAY_TYPES.has(value);
 }
 
 function toPageNumber(values: string[] | undefined): number | undefined {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,8 +21,7 @@
     "**/*.tsx",
     "next-env.d.ts",
     "types/**/*.d.ts",
-    ".next/types/**/*.ts",
     "scripts/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
## Summary
- add a dedicated pay type whitelist and type guard in `normalizeSearchParams`
- adjust the web app tsconfig to avoid compiling stale `.next` type outputs

## Testing
- pnpm -F @app/web typecheck *(fails in container: unable to download pnpm through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e57c84b4008327b9ded28dedbde129