### PR TITLE
feat: add sprint 4 database search layer

### DIFF
--- a/apps/web/docs/search/db-fts.md
+++ b/apps/web/docs/search/db-fts.md
@@ -1,0 +1,45 @@
+# Sprint 4 — Database Search Layer
+
+## Overview
+
+This sprint enables PostgreSQL full-text search (FTS) and trigram-based fuzzy matching for both performer profiles and job postings. Search vectors are generated in the database, stored alongside each row, and refreshed automatically via triggers so application queries can focus on ranking and pagination.
+
+## Search vector inputs
+
+### Profiles
+
+The profile `search_vector` aggregates the following fields after running them through `fa_unaccent` and the `simple` text search configuration:
+
+- `stageName`
+- `firstName`
+- `lastName`
+- `bio`
+- `skills` (flattened array)
+
+### Jobs
+
+The job `search_vector` aggregates:
+
+- `title`
+- `description`
+- `category`
+- `payType`
+
+## Indexes
+
+To keep queries fast the migration installs:
+
+- `idx_profile_search_vector` and `idx_job_search_vector` — GIN indexes over each `search_vector`
+- Trigram GIN indexes for profile stage/name combinations, job titles, and job cities to accelerate fuzzy matching
+
+## Ranking & fallbacks
+
+- Primary ranking uses `ts_rank_cd(search_vector, plainto_tsquery('simple', fa_unaccent(:query)))`
+- When fewer than three matches are returned, the server-side search falls back to trigram similarity on the concatenated display name (profiles) or title (jobs)
+- Trigram fallback keeps a similarity guard (`similarity >= 0.3`) before ordering by similarity and recency
+
+## Persian language notes
+
+- PostgreSQL's `simple` configuration combined with the `unaccent` extension gives reasonable tokenization for Persian text without stemming
+- Trigram (`pg_trgm`) indexes continue to work on Persian strings thanks to Unicode support, covering misspellings and half-spaces
+- Developers should continue normalizing user-facing strings via `fa_unaccent` or the helpers in `apps/web/lib/search/sql.ts` whenever adding new search surfaces

--- a/apps/web/lib/search/__tests__/sql-builders.test.ts
+++ b/apps/web/lib/search/__tests__/sql-builders.test.ts
@@ -1,0 +1,88 @@
+import { Prisma } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_PAGE_SIZE,
+  buildTsQuery,
+  resolveJobSort,
+  resolvePagination,
+  resolveProfileSort,
+} from "../sql";
+
+function sqlToString(fragment: Prisma.Sql): string {
+  return fragment.strings.join("");
+}
+
+describe("buildTsQuery", () => {
+  it("normalizes and parameterizes values", () => {
+    const fragment = buildTsQuery("  سلام دنیا  ");
+
+    expect(fragment.values).toEqual(["سلام دنیا"]);
+    expect(sqlToString(fragment)).toContain(
+      "plainto_tsquery('simple', fa_unaccent(",
+    );
+  });
+
+  it("throws on empty input", () => {
+    expect(() => buildTsQuery("   ")).toThrowError();
+  });
+});
+
+describe("resolvePagination", () => {
+  it("applies defaults", () => {
+    expect(resolvePagination({})).toEqual({
+      page: 1,
+      pageSize: DEFAULT_PAGE_SIZE,
+      offset: 0,
+    });
+  });
+
+  it("caps values to sensible bounds", () => {
+    expect(
+      resolvePagination({
+        page: -1,
+        pageSize: 0,
+        defaultPageSize: 20,
+      }),
+    ).toEqual({
+      page: 1,
+      pageSize: 20,
+      offset: 0,
+    });
+
+    expect(
+      resolvePagination({
+        page: 3,
+        pageSize: 15,
+      }),
+    ).toEqual({
+      page: 3,
+      pageSize: 15,
+      offset: 30,
+    });
+  });
+});
+
+describe("resolveProfileSort", () => {
+  it("uses rank for relevance", () => {
+    const clause = resolveProfileSort("relevance", true);
+    expect(sqlToString(clause)).toContain("ORDER BY rank DESC");
+  });
+
+  it("falls back to updatedAt when no query", () => {
+    const clause = resolveProfileSort(undefined, false);
+    expect(sqlToString(clause)).toContain("ORDER BY p.\"updatedAt\" DESC");
+  });
+});
+
+describe("resolveJobSort", () => {
+  it("prioritizes featured jobs", () => {
+    const clause = resolveJobSort("featured", false);
+    expect(sqlToString(clause)).toContain("ORDER BY (j.\"featuredUntil\" IS NOT NULL) DESC");
+  });
+
+  it("uses rank when relevant", () => {
+    const clause = resolveJobSort("relevance", true);
+    expect(sqlToString(clause)).toContain("ORDER BY rank DESC");
+  });
+});

--- a/apps/web/lib/search/runJobSearch.ts
+++ b/apps/web/lib/search/runJobSearch.ts
@@ -1,0 +1,146 @@
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+import {
+  DEFAULT_PAGE_SIZE,
+  SIMILARITY_THRESHOLD,
+  buildTsQuery,
+  resolveJobSort,
+  resolvePagination,
+} from "./sql";
+
+type JobSearchSort = "relevance" | "newest" | "featured" | "expiry";
+
+export type JobSearchParams = {
+  query?: string;
+  city?: string;
+  category?: string;
+  page?: number;
+  pageSize?: number;
+  sort?: JobSearchSort;
+};
+
+type JobRow = {
+  id: string;
+  title: string;
+  cityId: string | null;
+  category: string;
+  featuredUntil: Date | null;
+  updatedAt: Date;
+  rank?: number | null;
+  sim?: number | null;
+};
+
+type SearchResult<T> = {
+  items: T[];
+  page: number;
+  pageSize: number;
+};
+
+const JOB_BASE_WHERE = Prisma.sql`
+  j."status" = 'PUBLISHED'
+  AND j."moderation" = 'APPROVED'
+`;
+
+const JOB_TITLE_EXPRESSION = Prisma.sql`coalesce(j."title",'')`;
+
+export async function runJobSearch(
+  params: JobSearchParams,
+): Promise<SearchResult<JobRow>> {
+  const { page, pageSize, offset } = resolvePagination({
+    page: params.page,
+    pageSize: params.pageSize,
+    defaultPageSize: DEFAULT_PAGE_SIZE,
+  });
+
+  const cityClause = params.city
+    ? Prisma.sql`AND j."cityId" = ${params.city}`
+    : Prisma.sql``;
+
+  const categoryClause = params.category
+    ? Prisma.sql`AND j."category" = ${params.category}`
+    : Prisma.sql``;
+
+  const hasQuery = Boolean(params.query && params.query.trim().length > 0);
+
+  if (hasQuery && params.query) {
+    const normalizedQuery = params.query.trim();
+    const tsQuery = buildTsQuery(normalizedQuery);
+
+    const ftsRows = await prisma.$queryRaw<JobRow[]>(Prisma.sql`
+      SELECT
+        j."id",
+        j."title",
+        j."cityId",
+        j."category",
+        j."featuredUntil",
+        j."updatedAt",
+        ts_rank_cd(j.search_vector, ${tsQuery}) AS rank
+      FROM "Job" j
+      WHERE ${JOB_BASE_WHERE}
+      ${cityClause}
+      ${categoryClause}
+        AND j.search_vector @@ ${tsQuery}
+      ${resolveJobSort(params.sort, true)}
+      LIMIT ${pageSize} OFFSET ${offset}
+    `);
+
+    if (ftsRows.length >= 3) {
+      return { items: ftsRows, page, pageSize };
+    }
+
+    const trigramRows = await prisma.$queryRaw<JobRow[]>(Prisma.sql`
+      SELECT
+        j."id",
+        j."title",
+        j."cityId",
+        j."category",
+        j."featuredUntil",
+        j."updatedAt",
+        similarity(${JOB_TITLE_EXPRESSION}, fa_unaccent(${normalizedQuery})) AS sim
+      FROM "Job" j
+      WHERE ${JOB_BASE_WHERE}
+      ${cityClause}
+      ${categoryClause}
+        AND ${JOB_TITLE_EXPRESSION} % fa_unaccent(${normalizedQuery})
+        AND similarity(${JOB_TITLE_EXPRESSION}, fa_unaccent(${normalizedQuery})) >= ${SIMILARITY_THRESHOLD}
+      ${resolveJobTrigramSort(params.sort)}
+      LIMIT ${pageSize} OFFSET ${offset}
+    `);
+
+    return { items: trigramRows, page, pageSize };
+  }
+
+  const rows = await prisma.$queryRaw<JobRow[]>(Prisma.sql`
+    SELECT
+      j."id",
+      j."title",
+      j."cityId",
+      j."category",
+      j."featuredUntil",
+      j."updatedAt"
+    FROM "Job" j
+    WHERE ${JOB_BASE_WHERE}
+    ${cityClause}
+    ${categoryClause}
+    ${resolveJobSort(params.sort, false)}
+    LIMIT ${pageSize} OFFSET ${offset}
+  `);
+
+  return { items: rows, page, pageSize };
+}
+
+function resolveJobTrigramSort(sort: JobSearchSort | undefined): Prisma.Sql {
+  switch (sort) {
+    case "featured":
+      return Prisma.sql`ORDER BY (j."featuredUntil" IS NOT NULL) DESC, j."featuredUntil" DESC, j."updatedAt" DESC`;
+    case "expiry":
+      return Prisma.sql`ORDER BY j."featuredUntil" ASC NULLS LAST, j."updatedAt" DESC`;
+    case "newest":
+      return Prisma.sql`ORDER BY j."updatedAt" DESC`;
+    case "relevance":
+    default:
+      return Prisma.sql`ORDER BY sim DESC, j."updatedAt" DESC`;
+  }
+}

--- a/apps/web/lib/search/runProfileSearch.ts
+++ b/apps/web/lib/search/runProfileSearch.ts
@@ -1,0 +1,148 @@
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+import {
+  DEFAULT_PAGE_SIZE,
+  SIMILARITY_THRESHOLD,
+  buildTsQuery,
+  resolvePagination,
+  resolveProfileSort,
+} from "./sql";
+
+type ProfileSearchSort = "relevance" | "newest" | "alpha";
+
+export type ProfileSearchParams = {
+  query?: string;
+  city?: string;
+  skills?: string[];
+  page?: number;
+  pageSize?: number;
+  sort?: ProfileSearchSort;
+};
+
+type ProfileRow = {
+  id: string;
+  stageName: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  cityId: string | null;
+  rank?: number | null;
+  sim?: number | null;
+};
+
+type SearchResult<T> = {
+  items: T[];
+  page: number;
+  pageSize: number;
+};
+
+const PROFILE_BASE_WHERE = Prisma.sql`
+  p."visibility" = 'PUBLIC'
+  AND p."moderationStatus" = 'APPROVED'
+`;
+
+const PROFILE_NAME_EXPRESSION = Prisma.sql`
+  coalesce(p."stageName",'') || ' ' || coalesce(p."firstName",'') || ' ' || coalesce(p."lastName",'')
+`;
+
+export async function runProfileSearch(
+  params: ProfileSearchParams,
+): Promise<SearchResult<ProfileRow>> {
+  const { page, pageSize, offset } = resolvePagination({
+    page: params.page,
+    pageSize: params.pageSize,
+    defaultPageSize: DEFAULT_PAGE_SIZE,
+  });
+
+  const cityClause = params.city
+    ? Prisma.sql`AND p."cityId" = ${params.city}`
+    : Prisma.sql``;
+
+  const skillsClause = params.skills && params.skills.length > 0
+    ? Prisma.sql`
+        AND EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements_text(COALESCE(p."skills"::jsonb, '[]'::jsonb)) skill(value)
+          WHERE skill.value = ANY(${params.skills})
+        )
+      `
+    : Prisma.sql``;
+
+  const hasQuery = Boolean(params.query && params.query.trim().length > 0);
+
+  if (hasQuery && params.query) {
+    const normalizedQuery = params.query.trim();
+    const tsQuery = buildTsQuery(normalizedQuery);
+
+    const ftsRows = await prisma.$queryRaw<ProfileRow[]>(Prisma.sql`
+      SELECT
+        p."id",
+        p."stageName",
+        p."firstName",
+        p."lastName",
+        p."cityId",
+        ts_rank_cd(p.search_vector, ${tsQuery}) AS rank
+      FROM "Profile" p
+      WHERE ${PROFILE_BASE_WHERE}
+      ${cityClause}
+      ${skillsClause}
+        AND p.search_vector @@ ${tsQuery}
+      ${resolveProfileSort(params.sort, true)}
+      LIMIT ${pageSize} OFFSET ${offset}
+    `);
+
+    if (ftsRows.length >= 3) {
+      return { items: ftsRows, page, pageSize };
+    }
+
+    const trigramRows = await prisma.$queryRaw<ProfileRow[]>(Prisma.sql`
+      SELECT
+        p."id",
+        p."stageName",
+        p."firstName",
+        p."lastName",
+        p."cityId",
+        similarity(${PROFILE_NAME_EXPRESSION}, fa_unaccent(${normalizedQuery})) AS sim
+      FROM "Profile" p
+      WHERE ${PROFILE_BASE_WHERE}
+      ${cityClause}
+      ${skillsClause}
+        AND ${PROFILE_NAME_EXPRESSION} % fa_unaccent(${normalizedQuery})
+        AND similarity(${PROFILE_NAME_EXPRESSION}, fa_unaccent(${normalizedQuery})) >= ${SIMILARITY_THRESHOLD}
+      ${resolveTrigramSort(params.sort)}
+      LIMIT ${pageSize} OFFSET ${offset}
+    `);
+
+    return { items: trigramRows, page, pageSize };
+  }
+
+  const rows = await prisma.$queryRaw<ProfileRow[]>(Prisma.sql`
+    SELECT
+      p."id",
+      p."stageName",
+      p."firstName",
+      p."lastName",
+      p."cityId"
+    FROM "Profile" p
+    WHERE ${PROFILE_BASE_WHERE}
+    ${cityClause}
+    ${skillsClause}
+    ${resolveProfileSort(params.sort, false)}
+    LIMIT ${pageSize} OFFSET ${offset}
+  `);
+
+  return { items: rows, page, pageSize };
+}
+
+function resolveTrigramSort(sort: ProfileSearchSort | undefined): Prisma.Sql {
+  switch (sort) {
+    case "alpha":
+      return Prisma.sql`ORDER BY ${PROFILE_NAME_EXPRESSION} ASC`;
+    case "newest":
+      return Prisma.sql`ORDER BY p."updatedAt" DESC`;
+    case "relevance":
+    default:
+      return Prisma.sql`ORDER BY sim DESC, p."updatedAt" DESC`;
+  }
+}

--- a/apps/web/lib/search/sql.ts
+++ b/apps/web/lib/search/sql.ts
@@ -1,0 +1,90 @@
+import { Prisma } from "@prisma/client";
+
+type PaginationInput = {
+  page?: number;
+  pageSize?: number;
+  defaultPageSize?: number;
+};
+
+export const DEFAULT_PAGE_SIZE = 12;
+export const SIMILARITY_THRESHOLD = 0.3;
+
+export function buildTsQuery(query: string): Prisma.Sql {
+  const normalized = query.trim();
+
+  if (!normalized) {
+    throw new Error("Query must not be empty");
+  }
+
+  return Prisma.sql`plainto_tsquery('simple', fa_unaccent(${normalized}))`;
+}
+
+export function buildUnaccentText(value: string): Prisma.Sql {
+  const normalized = value.trim();
+
+  if (!normalized) {
+    throw new Error("Value must not be empty");
+  }
+
+  return Prisma.sql`fa_unaccent(${normalized})`;
+}
+
+export function resolvePagination({
+  page,
+  pageSize,
+  defaultPageSize = DEFAULT_PAGE_SIZE,
+}: PaginationInput) {
+  const size = Math.max(1, pageSize ?? defaultPageSize);
+  const currentPage = Math.max(1, page ?? 1);
+  const offset = (currentPage - 1) * size;
+
+  return { page: currentPage, pageSize: size, offset };
+}
+
+type ProfileSort = "relevance" | "newest" | "alpha" | undefined;
+type JobSort = "relevance" | "newest" | "featured" | "expiry" | undefined;
+
+export function resolveProfileSort(sort: ProfileSort, hasQuery: boolean): Prisma.Sql {
+  if (hasQuery) {
+    switch (sort) {
+      case "alpha":
+        return Prisma.sql`ORDER BY coalesce(p."stageName",'') || ' ' || coalesce(p."firstName",'') || ' ' || coalesce(p."lastName",'') ASC`;
+      case "newest":
+        return Prisma.sql`ORDER BY p."updatedAt" DESC`;
+      default:
+        return Prisma.sql`ORDER BY rank DESC, p."updatedAt" DESC`;
+    }
+  }
+
+  if (sort === "alpha") {
+    return Prisma.sql`ORDER BY coalesce(p."stageName",'') || ' ' || coalesce(p."firstName",'') || ' ' || coalesce(p."lastName",'') ASC`;
+  }
+
+  return Prisma.sql`ORDER BY p."updatedAt" DESC`;
+}
+
+export function resolveJobSort(sort: JobSort, hasQuery: boolean): Prisma.Sql {
+  if (hasQuery) {
+    switch (sort) {
+      case "featured":
+        return Prisma.sql`ORDER BY (j."featuredUntil" IS NOT NULL) DESC, j."featuredUntil" DESC, j."updatedAt" DESC`;
+      case "expiry":
+        return Prisma.sql`ORDER BY j."featuredUntil" ASC NULLS LAST, j."updatedAt" DESC`;
+      case "newest":
+        return Prisma.sql`ORDER BY j."updatedAt" DESC`;
+      default:
+        return Prisma.sql`ORDER BY rank DESC, j."updatedAt" DESC`;
+    }
+  }
+
+  switch (sort) {
+    case "featured":
+      return Prisma.sql`ORDER BY (j."featuredUntil" IS NOT NULL) DESC, j."featuredUntil" DESC, j."updatedAt" DESC`;
+    case "expiry":
+      return Prisma.sql`ORDER BY j."featuredUntil" ASC NULLS LAST, j."updatedAt" DESC`;
+    case "newest":
+    case "relevance":
+    case undefined:
+      return Prisma.sql`ORDER BY j."updatedAt" DESC`;
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,8 @@
     "db:seed": "prisma db seed",
     "user:create": "tsx scripts/new-user.ts",
     "enforce:profiles": "tsx scripts/enforce-publishability.ts",
-    "seo:baseline": "node scripts/lh-baseline.mjs"
+    "seo:baseline": "node scripts/lh-baseline.mjs",
+    "search:smoke": "tsx scripts/smoke-fts.ts"
   },
   "dependencies": {
     "@acme/ui": "file:../../packages/ui",

--- a/apps/web/prisma/migrations/20251009000000_sprint4_fts/migration.sql
+++ b/apps/web/prisma/migrations/20251009000000_sprint4_fts/migration.sql
@@ -1,0 +1,83 @@
+-- Enable extensions (safe if already installed)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- Add search_vector columns
+ALTER TABLE "Profile" ADD COLUMN IF NOT EXISTS search_vector tsvector;
+ALTER TABLE "Job"     ADD COLUMN IF NOT EXISTS search_vector tsvector;
+
+-- Helper: normalize text with unaccent
+-- (Using built-in unaccent; no custom dict needed)
+CREATE OR REPLACE FUNCTION public.fa_unaccent(text)
+RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+  SELECT unaccent($1)
+$$;
+
+-- Build vectors
+CREATE OR REPLACE FUNCTION public.profile_tsvector(p "Profile")
+RETURNS tsvector LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT
+    to_tsvector(
+      'simple',
+      fa_unaccent(
+        coalesce(p."stageName",'') || ' ' ||
+        coalesce(p."firstName",'') || ' ' ||
+        coalesce(p."lastName",'') || ' ' ||
+        coalesce(p."bio",'') || ' ' ||
+        array_to_string(COALESCE(p."skills"::text[], ARRAY[]::text[]), ' ')
+      )
+    )
+$$;
+
+CREATE OR REPLACE FUNCTION public.job_tsvector(j "Job")
+RETURNS tsvector LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT
+    to_tsvector(
+      'simple',
+      fa_unaccent(
+        coalesce(j."title",'') || ' ' ||
+        coalesce(j."description",'') || ' ' ||
+        coalesce(j."category",'') || ' ' ||
+        coalesce(j."payType",'')
+      )
+    )
+$$;
+
+-- Triggers to keep vectors fresh
+CREATE OR REPLACE FUNCTION public.profile_tsvector_trigger()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.search_vector := public.profile_tsvector(NEW);
+  RETURN NEW;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.job_tsvector_trigger()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.search_vector := public.job_tsvector(NEW);
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS profile_tsvector_update ON "Profile";
+CREATE TRIGGER profile_tsvector_update
+BEFORE INSERT OR UPDATE ON "Profile"
+FOR EACH ROW EXECUTE FUNCTION public.profile_tsvector_trigger();
+
+DROP TRIGGER IF EXISTS job_tsvector_update ON "Job";
+CREATE TRIGGER job_tsvector_update
+BEFORE INSERT OR UPDATE ON "Job"
+FOR EACH ROW EXECUTE FUNCTION public.job_tsvector_trigger();
+
+-- Backfill existing rows
+UPDATE "Profile" SET search_vector = public.profile_tsvector("Profile");
+UPDATE "Job"     SET search_vector = public.job_tsvector("Job");
+
+-- GIN indexes for FTS
+CREATE INDEX IF NOT EXISTS idx_profile_search_vector ON "Profile" USING GIN (search_vector);
+CREATE INDEX IF NOT EXISTS idx_job_search_vector     ON "Job"     USING GIN (search_vector);
+
+-- Trigram indexes for fuzzy/partial matching
+CREATE INDEX IF NOT EXISTS idx_profile_stage_trgm ON "Profile" USING GIN (coalesce("stageName",'') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_profile_name_trgm  ON "Profile" USING GIN ((coalesce("firstName",'') || ' ' || coalesce("lastName",'')) gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_job_title_trgm     ON "Job"     USING GIN (coalesce("title",'') gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_job_city_trgm      ON "Job"     USING GIN (coalesce("cityId",'') gin_trgm_ops);

--- a/apps/web/scripts/smoke-fts.ts
+++ b/apps/web/scripts/smoke-fts.ts
@@ -1,0 +1,44 @@
+import { runJobSearch } from "@/lib/search/runJobSearch";
+import { runProfileSearch } from "@/lib/search/runProfileSearch";
+
+async function main() {
+  const profileQueries = ["خواننده", "singer", "developer"];
+  const jobQueries = ["casting", "actor", "کارگردان"];
+
+  for (const query of profileQueries) {
+    const result = await runProfileSearch({ query, pageSize: 3 });
+    console.log(`Profiles for "${query}":`);
+    if (result.items.length === 0) {
+      console.log("  (no results)");
+      continue;
+    }
+    for (const item of result.items) {
+      const score = item.rank ?? item.sim ?? null;
+      console.log(
+        `  ${item.id} — ${[item.stageName, item.firstName, item.lastName]
+          .filter(Boolean)
+          .join(" ") || "(no name)"} — score=${score ?? "n/a"}`,
+      );
+    }
+  }
+
+  for (const query of jobQueries) {
+    const result = await runJobSearch({ query, pageSize: 3 });
+    console.log(`Jobs for "${query}":`);
+    if (result.items.length === 0) {
+      console.log("  (no results)");
+      continue;
+    }
+    for (const item of result.items) {
+      const score = item.rank ?? item.sim ?? null;
+      console.log(
+        `  ${item.id} — ${item.title} — score=${score ?? "n/a"}`,
+      );
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a Postgres migration that enables FTS vectors, refresh triggers, and trigram indexes for profiles and jobs
- implement typed SQL helpers plus profile/job search functions with tsquery ranking and trigram fallback
- document the search pipeline, add a smoke script, and cover helper logic with unit tests

## Testing
- pnpm -F @app/web prisma migrate dev -n sprint4_fts *(fails: pnpm download blocked by proxy)*
- pnpm -F @app/web prisma generate *(fails: pnpm download blocked by proxy)*
- pnpm -w dev *(fails: pnpm download blocked by proxy)*
- pnpm -F @app/web run search:smoke *(fails: pnpm download blocked by proxy)*
- pnpm -F @app/web test *(fails: pnpm download blocked by proxy)*
- npx --yes tsc --project apps/web/tsconfig.json --noEmit *(fails: existing repo type errors unrelated to change)*

------
https://chatgpt.com/codex/tasks/task_e_68e588610bd883278e37df65ed8fee96