### PR TITLE
feat: add orchestrators for job and profile searches

### DIFF
--- a/apps/web/lib/orchestrators/__tests__/orchestrators.test.ts
+++ b/apps/web/lib/orchestrators/__tests__/orchestrators.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hashKey } from "../util";
+
+const cacheCalls: { keys?: string[]; options?: unknown }[] = [];
+
+const unstableCacheMock = vi.hoisted(() => ({
+  unstable_cache: vi.fn((resolver: (...args: unknown[]) => unknown, keys?: string[], options?: unknown) => {
+    cacheCalls.push({ keys, options });
+    return resolver;
+  }),
+}));
+
+const runProfileSearchMock = vi.hoisted(() => vi.fn());
+const runJobSearchMock = vi.hoisted(() => vi.fn());
+const buildCanonicalMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/cache", () => unstableCacheMock);
+vi.mock("@/lib/search/runProfileSearch", () => ({
+  runProfileSearch: runProfileSearchMock,
+}));
+vi.mock("@/lib/search/runJobSearch", () => ({
+  runJobSearch: runJobSearchMock,
+}));
+vi.mock("@/lib/seo/canonical", () => ({
+  buildCanonical: buildCanonicalMock,
+}));
+
+describe("search orchestrators", () => {
+  const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  beforeEach(() => {
+    cacheCalls.length = 0;
+    runProfileSearchMock.mockReset();
+    runJobSearchMock.mockReset();
+    buildCanonicalMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("clamps invalid profile sort while still executing the search", async () => {
+    runProfileSearchMock.mockResolvedValue({
+      items: [{ id: "p1" }],
+      page: 1,
+      pageSize: 12,
+    });
+    buildCanonicalMock.mockReturnValue("profiles-canonical");
+
+    const { fetchProfilesOrchestrated } = await import("../profiles");
+
+    const result = await fetchProfilesOrchestrated({ query: "singer", sort: "invalid", page: 0 });
+
+    expect(runProfileSearchMock).toHaveBeenCalledTimes(1);
+    const params = runProfileSearchMock.mock.calls[0]?.[0];
+    expect(params).toMatchObject({ query: "singer", page: 1 });
+    expect(params?.sort).toBeUndefined();
+
+    expect(result.items).toHaveLength(1);
+    expect(result.appliedFilters).toEqual([{ key: "query", value: "singer" }]);
+    expect(result.canonical).toBe("profiles-canonical");
+
+    expect(buildCanonicalMock).toHaveBeenCalledWith(
+      "/profiles",
+      expect.objectContaining({ query: "singer", page: 1 }),
+    );
+    expect(buildCanonicalMock.mock.calls[0]?.[1]).not.toHaveProperty("sort");
+
+    const expectedHash = hashKey({ query: "singer", page: 1 });
+    expect(cacheCalls[0]?.keys).toEqual(["search:profiles", expectedHash]);
+    expect(cacheCalls[0]?.options).toMatchObject({
+      revalidate: 60,
+      tags: ["search:profiles", `search:profiles:${expectedHash}`],
+    });
+  });
+
+  it("produces canonical jobs URL with normalized params", async () => {
+    runJobSearchMock.mockResolvedValue({
+      items: [
+        { id: "job1" },
+        { id: "job2" },
+      ],
+      page: 2,
+      pageSize: 12,
+    });
+    buildCanonicalMock.mockReturnValue("jobs-canonical");
+
+    const { fetchJobsOrchestrated } = await import("../jobs");
+
+    const result = await fetchJobsOrchestrated({
+      query: "actor",
+      category: "casting",
+      sort: "featured",
+      page: "2",
+    });
+
+    expect(runJobSearchMock).toHaveBeenCalledWith({
+      query: "actor",
+      city: undefined,
+      category: "casting",
+      sort: "featured",
+      page: 2,
+    });
+
+    expect(result.page).toBe(2);
+    expect(result.appliedFilters).toEqual([
+      { key: "category", value: "casting" },
+      { key: "sort", value: "featured" },
+      { key: "query", value: "actor" },
+    ]);
+    expect(result.canonical).toBe("jobs-canonical");
+
+    expect(buildCanonicalMock).toHaveBeenCalledWith(
+      "/jobs",
+      expect.objectContaining({ category: "casting", sort: "featured", page: 2 }),
+    );
+
+    const expectedHash = hashKey({
+      query: "actor",
+      category: "casting",
+      sort: "featured",
+      page: 2,
+    });
+    expect(cacheCalls[1]?.keys).toEqual(["search:jobs", expectedHash]);
+    expect(cacheCalls[1]?.options).toMatchObject({
+      tags: ["search:jobs", `search:jobs:${expectedHash}`],
+    });
+  });
+
+  it("falls back to defaults when inputs are unusable", async () => {
+    runProfileSearchMock.mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 12,
+    });
+    buildCanonicalMock.mockReturnValue("profiles-default");
+
+    const { fetchProfilesOrchestrated } = await import("../profiles");
+
+    const result = await fetchProfilesOrchestrated({ page: "-5", sort: 123 } as unknown as URLSearchParams);
+
+    expect(runProfileSearchMock).toHaveBeenCalledWith({
+      query: undefined,
+      city: undefined,
+      skills: undefined,
+      sort: undefined,
+      page: 1,
+    });
+    expect(result.page).toBe(1);
+    expect(result.appliedFilters).toEqual([]);
+    expect(buildCanonicalMock).toHaveBeenLastCalledWith("/profiles", expect.objectContaining({ page: 1 }));
+  });
+
+  afterAll(() => {
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/web/lib/orchestrators/jobs.ts
+++ b/apps/web/lib/orchestrators/jobs.ts
@@ -1,0 +1,79 @@
+import { unstable_cache } from "next/cache";
+
+import { buildCanonical } from "@/lib/seo/canonical";
+import { runJobSearch, type JobSearchParams } from "@/lib/search/runJobSearch";
+import { DEFAULT_PAGE_SIZE } from "@/lib/search/sql";
+
+import { jobsQuerySchema, type JobsQueryInput } from "./schema";
+import {
+  buildAppliedFilters,
+  canonicalizeInput,
+  hashKey,
+  parseWithClamp,
+  type OrchestratedResult,
+} from "./util";
+
+const CACHE_TTL = 60; // seconds
+const TAG_PREFIX = "search:jobs";
+
+type JobSearchResult = Awaited<ReturnType<typeof runJobSearch>>;
+type JobItem = JobSearchResult["items"][number];
+
+export async function fetchJobsOrchestrated(
+  raw: URLSearchParams | Record<string, unknown>,
+): Promise<OrchestratedResult<JobItem>> {
+  const normalized = canonicalizeInput(raw);
+  const parsed = parseWithClamp(jobsQuerySchema, normalized);
+  if (parsed.clamped) {
+    console.warn("[orchestrator:jobs] input_clamped", {
+      issues: parsed.issues.map((issue) => ({ path: issue.path, message: issue.message })),
+    });
+  }
+
+  const filterParams = parsed.empty ? ({} as JobsQueryInput) : parsed.params;
+  const page = filterParams.page ?? 1;
+
+  const searchParams: JobSearchParams = {
+    query: filterParams.query,
+    city: filterParams.city,
+    category: filterParams.category,
+    sort: filterParams.sort,
+    page,
+  };
+
+  const cacheKeyHash = hashKey(searchParams);
+  const cacheKeys = [TAG_PREFIX, cacheKeyHash];
+  const tags = [`${TAG_PREFIX}`, `${TAG_PREFIX}:${cacheKeyHash}`];
+
+  const resolve = unstable_cache(
+    async () => {
+      const startedAt = Date.now();
+      const result = await runJobSearch(searchParams);
+      const durationMs = Date.now() - startedAt;
+      console.info("[orchestrator:jobs] search_complete", {
+        hash: cacheKeyHash,
+        durationMs,
+        page: result.page,
+        pageSize: result.pageSize,
+        itemCount: result.items.length,
+      });
+      return result;
+    },
+    cacheKeys,
+    { revalidate: CACHE_TTL, tags },
+  );
+
+  const data = await resolve();
+
+  if (parsed.empty) {
+    console.info("[orchestrator:jobs] default_params_applied", { hash: cacheKeyHash });
+  }
+
+  return {
+    items: data.items,
+    page: data.page,
+    pageSize: data.pageSize ?? DEFAULT_PAGE_SIZE,
+    canonical: buildCanonical("/jobs", { ...filterParams, page: data.page }),
+    appliedFilters: buildAppliedFilters(filterParams),
+  };
+}

--- a/apps/web/lib/orchestrators/profiles.ts
+++ b/apps/web/lib/orchestrators/profiles.ts
@@ -1,0 +1,79 @@
+import { unstable_cache } from "next/cache";
+
+import { buildCanonical } from "@/lib/seo/canonical";
+import { runProfileSearch, type ProfileSearchParams } from "@/lib/search/runProfileSearch";
+import { DEFAULT_PAGE_SIZE } from "@/lib/search/sql";
+
+import { profilesQuerySchema, type ProfilesQueryInput } from "./schema";
+import {
+  buildAppliedFilters,
+  canonicalizeInput,
+  hashKey,
+  parseWithClamp,
+  type OrchestratedResult,
+} from "./util";
+
+const CACHE_TTL = 60; // seconds
+const TAG_PREFIX = "search:profiles";
+
+type ProfileSearchResult = Awaited<ReturnType<typeof runProfileSearch>>;
+type ProfileItem = ProfileSearchResult["items"][number];
+
+export async function fetchProfilesOrchestrated(
+  raw: URLSearchParams | Record<string, unknown>,
+): Promise<OrchestratedResult<ProfileItem>> {
+  const normalized = canonicalizeInput(raw);
+  const parsed = parseWithClamp(profilesQuerySchema, normalized);
+  if (parsed.clamped) {
+    console.warn("[orchestrator:profiles] input_clamped", {
+      issues: parsed.issues.map((issue) => ({ path: issue.path, message: issue.message })),
+    });
+  }
+
+  const filterParams = parsed.empty ? ({} as ProfilesQueryInput) : parsed.params;
+  const page = filterParams.page ?? 1;
+
+  const searchParams: ProfileSearchParams = {
+    query: filterParams.query,
+    city: filterParams.city,
+    skills: filterParams.skills,
+    sort: filterParams.sort,
+    page,
+  };
+
+  const cacheKeyHash = hashKey(searchParams);
+  const cacheKeys = [TAG_PREFIX, cacheKeyHash];
+  const tags = [`${TAG_PREFIX}`, `${TAG_PREFIX}:${cacheKeyHash}`];
+
+  const resolve = unstable_cache(
+    async () => {
+      const startedAt = Date.now();
+      const result = await runProfileSearch(searchParams);
+      const durationMs = Date.now() - startedAt;
+      console.info("[orchestrator:profiles] search_complete", {
+        hash: cacheKeyHash,
+        durationMs,
+        page: result.page,
+        pageSize: result.pageSize,
+        itemCount: result.items.length,
+      });
+      return result;
+    },
+    cacheKeys,
+    { revalidate: CACHE_TTL, tags },
+  );
+
+  const data = await resolve();
+
+  if (parsed.empty) {
+    console.info("[orchestrator:profiles] default_params_applied", { hash: cacheKeyHash });
+  }
+
+  return {
+    items: data.items,
+    page: data.page,
+    pageSize: data.pageSize ?? DEFAULT_PAGE_SIZE,
+    canonical: buildCanonical("/profiles", { ...filterParams, page: data.page }),
+    appliedFilters: buildAppliedFilters(filterParams),
+  };
+}

--- a/apps/web/lib/orchestrators/schema.ts
+++ b/apps/web/lib/orchestrators/schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const sortProfileEnum = z.enum(["relevance", "newest", "alpha"]).optional();
+export const sortJobEnum = z.enum(["relevance", "newest", "featured", "expiry"]).optional();
+
+export const baseQuerySchema = z.object({
+  query: z.string().trim().min(1).optional(),
+  city: z.string().trim().optional(),
+  skills: z.array(z.string().trim()).optional(),
+  page: z.coerce.number().int().positive().optional(),
+});
+
+export const profilesQuerySchema = baseQuerySchema.extend({
+  sort: sortProfileEnum,
+});
+
+export const jobsQuerySchema = baseQuerySchema.extend({
+  category: z.string().trim().optional(),
+  sort: sortJobEnum,
+});
+
+export type ProfilesQueryInput = z.infer<typeof profilesQuerySchema>;
+export type JobsQueryInput = z.infer<typeof jobsQuerySchema>;

--- a/apps/web/lib/orchestrators/util.ts
+++ b/apps/web/lib/orchestrators/util.ts
@@ -1,0 +1,112 @@
+import crypto from "node:crypto";
+import { z, type ZodIssue } from "zod";
+
+import { normalizeSearchParams } from "@/lib/url/normalizeSearchParams";
+
+export function canonicalizeInput(raw: URLSearchParams | Record<string, unknown>) {
+  const norm = normalizeSearchParams(
+    raw instanceof URLSearchParams ? raw : toNormalizedRecord(raw),
+  );
+  const clean: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(norm)) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    clean[key] = value;
+  }
+
+  return clean;
+}
+
+function toNormalizedRecord(raw: Record<string, unknown>) {
+  const record: Record<string, string | string[] | undefined> = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      record[key] = value.map((entry) => String(entry));
+      continue;
+    }
+
+    record[key] = String(value);
+  }
+
+  return record;
+}
+
+export function hashKey(obj: unknown) {
+  return crypto.createHash("sha1").update(JSON.stringify(obj)).digest("hex").slice(0, 10);
+}
+
+export function buildAppliedFilters(p: Record<string, unknown>) {
+  const chips: { key: string; value: string }[] = [];
+
+  if (p.city) {
+    chips.push({ key: "city", value: String(p.city) });
+  }
+  if (Array.isArray(p.skills) && p.skills.length) {
+    chips.push({ key: "skills", value: p.skills.join(", ") });
+  }
+  if (p.category) {
+    chips.push({ key: "category", value: String(p.category) });
+  }
+  if (p.sort) {
+    chips.push({ key: "sort", value: String(p.sort) });
+  }
+  if (p.query) {
+    chips.push({ key: "query", value: String(p.query) });
+  }
+
+  return chips;
+}
+
+export type OrchestratedResult<T> = {
+  items: T[];
+  page: number;
+  pageSize: number;
+  canonical: string;
+  appliedFilters: { key: string; value: string }[];
+};
+
+export type ParseOutcome<T> = {
+  params: T;
+  issues: ZodIssue[];
+  clamped: boolean;
+  empty: boolean;
+};
+
+export function parseWithClamp<T extends z.ZodTypeAny>(schema: T, normalized: Record<string, unknown>): ParseOutcome<z.infer<T>> {
+  const initial = schema.safeParse(normalized);
+  if (initial.success) {
+    return { params: initial.data, issues: [], clamped: false, empty: false };
+  }
+
+  const sanitized: Record<string, unknown> = { ...normalized };
+  let removedAny = false;
+
+  for (const issue of initial.error.issues) {
+    const key = issue.path[0];
+    if (typeof key === "string" && key in sanitized) {
+      delete sanitized[key];
+      removedAny = true;
+    }
+  }
+
+  if (removedAny) {
+    const retry = schema.safeParse(sanitized);
+    if (retry.success) {
+      return { params: retry.data, issues: initial.error.issues, clamped: true, empty: false };
+    }
+  }
+
+  return {
+    params: {} as z.infer<T>,
+    issues: initial.error.issues,
+    clamped: true,
+    empty: true,
+  };
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,8 @@
     "user:create": "tsx scripts/new-user.ts",
     "enforce:profiles": "tsx scripts/enforce-publishability.ts",
     "seo:baseline": "node scripts/lh-baseline.mjs",
-    "search:smoke": "tsx scripts/smoke-fts.ts"
+    "search:smoke": "tsx scripts/smoke-fts.ts",
+    "orchestrators:smoke": "tsx scripts/smoke-orchestrators.ts"
   },
   "dependencies": {
     "@acme/ui": "file:../../packages/ui",

--- a/apps/web/scripts/smoke-orchestrators.ts
+++ b/apps/web/scripts/smoke-orchestrators.ts
@@ -1,0 +1,29 @@
+import { fetchProfilesOrchestrated } from "@/lib/orchestrators/profiles";
+import { fetchJobsOrchestrated } from "@/lib/orchestrators/jobs";
+
+async function main() {
+  const p = await fetchProfilesOrchestrated({ query: "singer", city: "tehran", page: 1 });
+  console.log(
+    "Profiles:",
+    p.page,
+    p.pageSize,
+    p.appliedFilters,
+    p.items.slice(0, 3).map((item) => item.id),
+    p.canonical,
+  );
+
+  const j = await fetchJobsOrchestrated({ query: "actor", category: "casting", page: 1 });
+  console.log(
+    "Jobs:",
+    j.page,
+    j.pageSize,
+    j.appliedFilters,
+    j.items.slice(0, 3).map((item) => item.id),
+    j.canonical,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add shared Zod schema and orchestrator utilities for search queries
- implement cached profile and job orchestrators that normalize inputs, map to search runners, and expose canonical metadata
- provide a smoke script and targeted vitest coverage for the new orchestrators

## Testing
- pnpm -w dev *(fails: network access to pnpm registry is blocked in the execution environment)*
- pnpm -F @app/web run orchestrators:smoke *(fails: network access to pnpm registry is blocked in the execution environment)*
- pnpm -F @app/web test --filter="apps/web#lib/orchestrators" *(fails: network access to pnpm registry is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ae91551883279f00bac517a89fbd