### PR TITLE
feat: build SSR profiles directory filters

### DIFF
--- a/apps/web/app/(public)/profiles/loading.tsx
+++ b/apps/web/app/(public)/profiles/loading.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ProfilesLoading() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10" dir="rtl">
+      <header className="space-y-3">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-64" />
+      </header>
+
+      <Card className="border-border bg-background/60">
+        <CardHeader className="pb-4">
+          <Skeleton className="h-6 w-32" />
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-12 w-full" />
+          ))}
+          <Skeleton className="lg:col-span-2 h-24 w-full" />
+        </CardContent>
+      </Card>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <Card key={index} className="h-48">
+            <CardContent className="flex h-full flex-col gap-4 pt-6">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-3/4" />
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(public)/profiles/page.tsx
+++ b/apps/web/app/(public)/profiles/page.tsx
@@ -1,47 +1,445 @@
+import Link from "next/link";
 import type { Metadata } from "next";
 
+import { Badge, badgeVariants } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getCities } from "@/lib/location/cities";
+import { fetchProfilesOrchestrated } from "@/lib/orchestrators/profiles";
+import { SKILLS } from "@/lib/profile/skills";
 import { buildCanonical } from "@/lib/seo/canonical";
-import { normalizeSearchParams } from "@/lib/url/normalizeSearchParams";
+import {
+  normalizeSearchParams,
+  type NormalizedSearchParams,
+} from "@/lib/url/normalizeSearchParams";
+import { parseSkillsSearchParam, setSkillsSearchParam } from "@/lib/url/skillsParam";
+import { cn } from "@/lib/utils";
 
-// Sprint 4 Phase 1: Listings rendered via SSR; details remain ISR
+const PAGE_TITLE = "فهرست پروفایل‌ها";
+const DEFAULT_PAGE_SIZE = 12;
 
-const PAGE_TITLE = "Profiles directory (Phase 1 baseline)";
+const SKILL_LABELS = new Map(SKILLS.map((skill) => [skill.key, skill.label] as const));
+
+const SORT_OPTIONS = [
+  { value: "relevance", label: "مرتبط‌ترین" },
+  { value: "newest", label: "جدیدترین" },
+  { value: "alpha", label: "مرتب‌سازی الفبا" },
+] as const;
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
-type PageProps = {
-  searchParams: SearchParams;
-};
+const UPDATED_AT_FORMATTER = new Intl.DateTimeFormat("fa-IR", {
+  dateStyle: "medium",
+});
 
 export async function generateMetadata({ searchParams }: { searchParams: SearchParams }): Promise<Metadata> {
-  const canonical = buildCanonical("/profiles", searchParams);
-
   return {
     title: PAGE_TITLE,
     alternates: {
-      canonical,
+      canonical: buildCanonical("/profiles", searchParams),
     },
   };
 }
 
-export default function ProfilesPage({ searchParams }: PageProps) {
+export default async function ProfilesPage({ searchParams }: { searchParams: SearchParams }) {
   const normalized = normalizeSearchParams(searchParams);
+  const selectedSkills = parseSkillsSearchParam(searchParams);
+
+  const [data, cities] = await Promise.all([
+    fetchProfilesOrchestrated(searchParams),
+    getCities(),
+  ]);
+
+  const cityMap = new Map(cities.map((city) => [city.id, city.name] as const));
+  const currentPage = data.page ?? normalized.page ?? 1;
+  const pageSize = data.pageSize ?? DEFAULT_PAGE_SIZE;
+  const hasNextPage = data.items.length === pageSize;
+  const hasPrevPage = currentPage > 1;
+
+  const normalizedForLinks: NormalizedSearchParams = {
+    ...normalized,
+    page: currentPage,
+    skills: selectedSkills.length ? selectedSkills : normalized.skills,
+  };
+
+  const appliedFilters = data.appliedFilters.map((chip) => {
+    const formattedValue = formatFilterValue(chip.key, chip.value, {
+      cityMap,
+    });
+
+    const href = buildHref(normalizedForLinks, () => {
+      if (chip.key === "skills") {
+        return { skills: undefined, page: undefined };
+      }
+      return { [chip.key]: undefined, page: undefined } as Partial<NormalizedSearchParams>;
+    });
+
+    return { ...chip, label: formattedValue, href };
+  });
 
   return (
-    <section className="mx-auto flex max-w-4xl flex-col gap-6 py-10" dir="rtl">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold text-foreground">فهرست پروفایل‌ها</h1>
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10" dir="rtl">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-semibold text-foreground">{PAGE_TITLE}</h1>
         <p className="text-sm text-muted-foreground">
-          زیرساخت جستجو در حال آماده‌سازی است. این صفحه از پارامترهای URL برای تعیین فیلترها و وضعیت
-          صفحه استفاده خواهد کرد.
+          جستجو و فیلتر پروفایل‌های تایید‌شده هنرمندان براساس نام، شهر، مهارت‌ها و سایر معیارها.
         </p>
       </header>
-      <div className="space-y-4 rounded-lg border border-dashed border-border bg-muted/20 p-4 text-sm">
-        <p className="font-medium text-foreground">پارامترهای نرمال‌سازی شده</p>
-        <pre className="overflow-auto rounded-md bg-background p-4 text-xs shadow-sm">
-          {JSON.stringify(normalized, null, 2)}
-        </pre>
-      </div>
-    </section>
+
+      <Card className="border-border bg-background/60">
+        <CardHeader className="pb-4">
+          <CardTitle className="text-xl">فیلترها</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form method="get" className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="profiles-query">جستجو</Label>
+              <Input
+                id="profiles-query"
+                name="query"
+                type="search"
+                placeholder="نام هنرمند یا مهارت"
+                defaultValue={normalized.query ?? ""}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="profiles-city">شهر</Label>
+              <select
+                id="profiles-city"
+                name="city"
+                defaultValue={normalized.city ?? ""}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <option value="">همه شهرها</option>
+                {cities.map((city) => (
+                  <option key={city.id} value={city.id}>
+                    {city.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2 lg:col-span-2">
+              <Label htmlFor="profiles-skills">مهارت‌ها</Label>
+              <select
+                id="profiles-skills"
+                name="skills"
+                multiple
+                defaultValue={selectedSkills}
+                size={Math.min(6, SKILLS.length)}
+                className="min-h-[2.5rem] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                {SKILLS.map((skill) => (
+                  <option key={skill.key} value={skill.key}>
+                    {skill.label}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground">
+                برای انتخاب چند مهارت، کلید Ctrl یا Command را نگه دارید.
+              </p>
+            </div>
+
+            <fieldset className="flex flex-col gap-3">
+              <legend className="text-sm font-medium">جنسیت</legend>
+              <div className="flex flex-wrap gap-4 text-sm text-foreground">
+                <div className="flex items-center gap-2">
+                  <input
+                    id="profiles-gender-male"
+                    name="gender"
+                    type="radio"
+                    value="male"
+                    defaultChecked={normalized.gender === "male"}
+                    className="h-4 w-4 border border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  />
+                  <Label htmlFor="profiles-gender-male" className="cursor-pointer">
+                    مرد
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    id="profiles-gender-female"
+                    name="gender"
+                    type="radio"
+                    value="female"
+                    defaultChecked={normalized.gender === "female"}
+                    className="h-4 w-4 border border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  />
+                  <Label htmlFor="profiles-gender-female" className="cursor-pointer">
+                    زن
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    id="profiles-gender-other"
+                    name="gender"
+                    type="radio"
+                    value="other"
+                    defaultChecked={normalized.gender === "other"}
+                    className="h-4 w-4 border border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  />
+                  <Label htmlFor="profiles-gender-other" className="cursor-pointer">
+                    سایر
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    id="profiles-gender-any"
+                    name="gender"
+                    type="radio"
+                    value=""
+                    defaultChecked={!normalized.gender}
+                    className="h-4 w-4 border border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  />
+                  <Label htmlFor="profiles-gender-any" className="cursor-pointer">
+                    بدون فیلتر
+                  </Label>
+                </div>
+              </div>
+            </fieldset>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="profiles-sort">مرتب‌سازی</Label>
+              <select
+                id="profiles-sort"
+                name="sort"
+                defaultValue={normalized.sort ?? ""}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <option value="">پیش‌فرض (مرتبط‌ترین)</option>
+                {SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex items-end">
+              <Button type="submit" className="w-full lg:w-auto">
+                اعمال فیلترها
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {appliedFilters.length ? (
+        <section aria-label="فیلترهای اعمال شده" className="flex flex-wrap gap-2">
+          {appliedFilters.map((chip) => (
+            <a
+              key={chip.key}
+              href={chip.href}
+              className={cn(
+                badgeVariants({ variant: "outline" }),
+                "group inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              )}
+              aria-label={`حذف فیلتر ${chip.label}`}
+            >
+              <span>{chip.label}</span>
+              <span aria-hidden className="text-muted-foreground">×</span>
+            </a>
+          ))}
+        </section>
+      ) : null}
+
+      {data.items.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {data.items.map((item) => {
+            const displayName = resolveDisplayName(item);
+            const cityName = item.cityId ? cityMap.get(item.cityId) ?? item.cityId : undefined;
+            const skills = resolveSkillBadges(item.skills);
+            const updatedAtLabel = item.updatedAt
+              ? UPDATED_AT_FORMATTER.format(new Date(item.updatedAt))
+              : undefined;
+
+            return (
+              <Link
+                key={item.id}
+                href={`/profiles/${item.id}`}
+                className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <Card className="h-full transition group-hover:shadow-md">
+                  <CardHeader className="space-y-1">
+                    <CardTitle className="text-xl">{displayName}</CardTitle>
+                    {cityName ? (
+                      <p className="text-sm text-muted-foreground">ساکن {cityName}</p>
+                    ) : null}
+                  </CardHeader>
+                  <CardContent className="flex flex-col gap-4">
+                    {skills.length ? (
+                      <div className="flex flex-wrap gap-2">
+                        {skills.slice(0, 4).map((skill) => (
+                          <Badge key={skill.key} variant="secondary" className="rounded-full px-3 py-1 text-xs">
+                            {skill.label}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">مهارتی ثبت نشده است.</p>
+                    )}
+                    {updatedAtLabel ? (
+                      <p className="text-xs text-muted-foreground">به‌روزرسانی: {updatedAtLabel}</p>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </section>
+      )}
+
+      <footer className="flex flex-col gap-4 rounded-lg border border-border bg-background/60 p-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+        <span>
+          صفحه {currentPage}
+          {hasNextPage ? "" : " (آخرین صفحه)"}
+        </span>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasPrevPage}
+            asChild={hasPrevPage}
+          >
+            {hasPrevPage ? (
+              <Link href={buildHref(normalizedForLinks, () => ({
+                page: currentPage - 1 > 1 ? currentPage - 1 : undefined,
+              }))}>
+                قبلی
+              </Link>
+            ) : (
+              <>قبلی</>
+            )}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasNextPage}
+            asChild={hasNextPage}
+          >
+            {hasNextPage ? (
+              <Link href={buildHref(normalizedForLinks, () => ({
+                page: currentPage + 1,
+              }))}>
+                بعدی
+              </Link>
+            ) : (
+              <>بعدی</>
+            )}
+          </Button>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+type FilterFormatterContext = {
+  cityMap: Map<string, string>;
+};
+
+function formatFilterValue(key: string, value: string, context: FilterFormatterContext) {
+  switch (key) {
+    case "query":
+      return `جستجو: ${value}`;
+    case "city":
+      return `شهر: ${context.cityMap.get(value) ?? value}`;
+    case "skills": {
+      const parts = value.split(",");
+      const labels = parts
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .map((part) => SKILL_LABELS.get(part) ?? part);
+      return `مهارت‌ها: ${labels.join("، ")}`;
+    }
+    case "sort": {
+      const label = SORT_OPTIONS.find((option) => option.value === value)?.label ?? value;
+      return `مرتب‌سازی: ${label}`;
+    }
+    default:
+      return value;
+  }
+}
+
+function buildHref(
+  normalized: NormalizedSearchParams,
+  overridesFactory: () => Partial<NormalizedSearchParams>,
+) {
+  const overrides = overridesFactory();
+  const next: NormalizedSearchParams = { ...normalized, ...overrides };
+
+  const params = new URLSearchParams();
+
+  if (next.query) params.set("query", next.query);
+  if (next.city) params.set("city", next.city);
+  if (next.gender) params.set("gender", next.gender);
+  if (next.sort) params.set("sort", next.sort);
+  if (next.remote) params.set("remote", next.remote);
+  if (next.category) params.set("category", next.category);
+  if (next.payType) params.set("payType", next.payType);
+  if (next.featured) params.set("featured", next.featured);
+  if (Array.isArray(next.skills) && next.skills.length) {
+    setSkillsSearchParam(params, next.skills);
+  }
+
+  const pageValue = overrides.page ?? next.page;
+  if (pageValue && pageValue > 1) {
+    params.set("page", pageValue.toString());
+  }
+
+  const search = params.toString();
+  return search ? `/profiles?${search}` : "/profiles";
+}
+
+function resolveDisplayName(item: {
+  stageName: string | null;
+  firstName: string | null;
+  lastName: string | null;
+}) {
+  if (item.stageName && item.stageName.trim()) {
+    return item.stageName.trim();
+  }
+  const parts = [item.firstName ?? "", item.lastName ?? ""].map((part) => part.trim()).filter(Boolean);
+  return parts.join(" ") || "پروفایل";
+}
+
+function resolveSkillBadges(raw: unknown) {
+  if (!Array.isArray(raw)) {
+    return [] as { key: string; label: string }[];
+  }
+
+  const badges: { key: string; label: string }[] = [];
+  const seen = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    if (seen.has(entry)) {
+      continue;
+    }
+    seen.add(entry);
+    badges.push({ key: entry, label: SKILL_LABELS.get(entry) ?? entry });
+    if (badges.length >= 8) {
+      break;
+    }
+  }
+  return badges;
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border bg-muted/30 p-10 text-center">
+      <p className="text-base font-medium text-foreground">هنرمندی با فیلترهای انتخابی یافت نشد.</p>
+      <p className="text-sm text-muted-foreground">
+        فیلترها را تغییر دهید یا جستجوی جدیدی انجام دهید.
+      </p>
+      <Button variant="link" asChild>
+        <Link href="/profiles">حذف همه فیلترها</Link>
+      </Button>
+    </div>
   );
 }

--- a/apps/web/lib/search/runProfileSearch.ts
+++ b/apps/web/lib/search/runProfileSearch.ts
@@ -27,6 +27,8 @@ type ProfileRow = {
   firstName: string | null;
   lastName: string | null;
   cityId: string | null;
+  skills: Prisma.JsonValue | null;
+  updatedAt: Date;
   rank?: number | null;
   sim?: number | null;
 };
@@ -85,6 +87,8 @@ export async function runProfileSearch(
         p."firstName",
         p."lastName",
         p."cityId",
+        p."skills",
+        p."updatedAt",
         ts_rank_cd(p.search_vector, ${createTsQuery()}) AS rank
       FROM "Profile" p
       WHERE ${PROFILE_BASE_WHERE}
@@ -106,6 +110,8 @@ export async function runProfileSearch(
         p."firstName",
         p."lastName",
         p."cityId",
+        p."skills",
+        p."updatedAt",
         similarity(${PROFILE_NAME_EXPRESSION}, fa_unaccent(${normalizedQuery})) AS sim
       FROM "Profile" p
       WHERE ${PROFILE_BASE_WHERE}
@@ -126,7 +132,9 @@ export async function runProfileSearch(
       p."stageName",
       p."firstName",
       p."lastName",
-      p."cityId"
+      p."cityId",
+      p."skills",
+      p."updatedAt"
     FROM "Profile" p
     WHERE ${PROFILE_BASE_WHERE}
     ${cityClause}

--- a/apps/web/lib/url/__tests__/skillsParam.test.ts
+++ b/apps/web/lib/url/__tests__/skillsParam.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSkillsSearchParam, setSkillsSearchParam } from "../skillsParam";
+
+describe("skills search param helpers", () => {
+  it("parses comma separated values", () => {
+    const result = parseSkillsSearchParam({ skills: "singing_pop, music_instrument_guitar" });
+
+    expect(result).toEqual(["singing_pop", "music_instrument_guitar"]);
+  });
+
+  it("deduplicates and trims when serializing", () => {
+    const params = new URLSearchParams();
+
+    setSkillsSearchParam(params, ["singing_pop", " ", "singing_pop", "dance_modern"]);
+
+    expect(params.get("skills")).toBe("singing_pop,dance_modern");
+  });
+
+  it("removes the param when no skills remain", () => {
+    const params = new URLSearchParams();
+    params.set("skills", "existing");
+
+    setSkillsSearchParam(params, []);
+
+    expect(params.has("skills")).toBe(false);
+  });
+});

--- a/apps/web/lib/url/skillsParam.ts
+++ b/apps/web/lib/url/skillsParam.ts
@@ -1,0 +1,53 @@
+export type SearchParamInput = Record<string, string | string[] | undefined>;
+
+function collectRawValues(raw: string | string[] | undefined): string[] {
+  if (raw === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+
+  return [raw];
+}
+
+export function parseSkillsSearchParam(searchParams: SearchParamInput): string[] {
+  const rawValues = collectRawValues(searchParams.skills);
+  const seen = new Set<string>();
+  const skills: string[] = [];
+
+  for (const value of rawValues) {
+    const segments = value.split(",");
+    for (const segment of segments) {
+      const trimmed = segment.trim();
+      if (!trimmed || seen.has(trimmed)) {
+        continue;
+      }
+      seen.add(trimmed);
+      skills.push(trimmed);
+    }
+  }
+
+  return skills;
+}
+
+export function setSkillsSearchParam(target: URLSearchParams, values: Iterable<string>) {
+  target.delete("skills");
+
+  const deduped: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    deduped.push(trimmed);
+  }
+
+  if (deduped.length > 0) {
+    target.set("skills", deduped.join(","));
+  }
+}


### PR DESCRIPTION
## Summary
- implement the /profiles server-rendered directory with form filters, result cards, and pagination wired to fetchProfilesOrchestrated
- add shared helpers for comma-separated skills parameters with dedicated unit coverage
- expose profile skills and updated timestamps from the search query and provide an initial loading skeleton

## Testing
- `pnpm --filter @app/web test -- --runInBand` *(fails: corepack cannot download pnpm binary in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e68a22834883279fd28d180e0d730f