### PR TITLE
Export reusable skill key guard

### DIFF
--- a/apps/web/app/(public)/profiles/page.tsx
+++ b/apps/web/app/(public)/profiles/page.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getCities } from "@/lib/location/cities";
 import { fetchProfilesOrchestrated } from "@/lib/orchestrators/profiles";
-import { SKILLS } from "@/lib/profile/skills";
+import { SKILLS, isSkillKey, type SkillKey } from "@/lib/profile/skills";
 import { buildCanonical } from "@/lib/seo/canonical";
 import {
   normalizeSearchParams,
@@ -353,7 +353,7 @@ function formatFilterValue(key: string, value: string, context: FilterFormatterC
       const labels = parts
         .map((part) => part.trim())
         .filter(Boolean)
-        .map((part) => SKILL_LABELS.get(part) ?? part);
+        .map((part) => (isSkillKey(part) ? SKILL_LABELS.get(part) ?? part : part));
       return `مهارت‌ها: ${labels.join("، ")}`;
     }
     case "sort": {
@@ -422,6 +422,9 @@ function resolveSkillBadges(raw: unknown) {
       continue;
     }
     seen.add(entry);
+    if (!isSkillKey(entry)) {
+      continue;
+    }
     badges.push({ key: entry, label: SKILL_LABELS.get(entry) ?? entry });
     if (badges.length >= 8) {
       break;
@@ -443,3 +446,4 @@ function EmptyState() {
     </div>
   );
 }
+

--- a/apps/web/app/admin/moderation/[id]/page.tsx
+++ b/apps/web/app/admin/moderation/[id]/page.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getCities } from "@/lib/location/cities";
 import { getModerationDetail } from "@/lib/profile/moderation";
-import { SKILLS, type SkillKey } from "@/lib/profile/skills";
+import { SKILLS, isSkillKey, type SkillKey } from "@/lib/profile/skills";
 
 import { ModerationActions } from "../_components/moderation-actions";
 
@@ -51,12 +51,6 @@ const EVENT_LABELS: EventLabelMap = {
 const SKILL_LABELS = new Map<SkillKey, string>(
   SKILLS.map((skill) => [skill.key, skill.label] as const),
 );
-const SKILL_KEYS = new Set<string>(SKILLS.map((skill) => skill.key));
-
-function isSkillKey(value: unknown): value is SkillKey {
-  return typeof value === "string" && SKILL_KEYS.has(value);
-}
-
 function getDisplayName(
   stageName?: string | null,
   firstName?: string | null,

--- a/apps/web/lib/profile/skills.ts
+++ b/apps/web/lib/profile/skills.ts
@@ -32,3 +32,9 @@ export const SKILLS: { key: SkillKey; label: string; category: string }[] = [
 ];
 
 export const SKILL_KEYS = SKILLS.map((skill) => skill.key) as SkillKey[];
+
+const SKILL_KEY_SET = new Set<SkillKey>(SKILL_KEYS);
+
+export function isSkillKey(value: unknown): value is SkillKey {
+  return typeof value === "string" && SKILL_KEY_SET.has(value as SkillKey);
+}


### PR DESCRIPTION
## Summary
- export an `isSkillKey` helper from the skills module for reuse
- use the shared guard when formatting profile filters and moderation badges

## Testing
- pnpm -F @app/web typecheck *(fails: corepack cannot download pnpm due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e68ee9939c8327a10d88c0b1f2040f