### PR TITLE
Fix lint issues in billing tests and shared UI utilities

### DIFF
--- a/apps/web/app/_error-boundary.tsx
+++ b/apps/web/app/_error-boundary.tsx
@@ -2,8 +2,8 @@
 import React from "react";
 
 export class RootErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
-  state = { hasError: false };
-  componentDidCatch(error: any, info: any) {
+  state: Readonly<{ hasError: boolean }> = { hasError: false };
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
     // eslint-disable-next-line no-console
     console.error("💥 Caught error:", error);
     // eslint-disable-next-line no-console

--- a/apps/web/app/_slot-debug-provider.tsx
+++ b/apps/web/app/_slot-debug-provider.tsx
@@ -5,12 +5,29 @@ import * as React from "react";
 // Set NEXT_PUBLIC_DEBUG_SLOT=1 in apps/web/.env.local to enable
 const ENABLED = process.env.NEXT_PUBLIC_DEBUG_SLOT === "1";
 
+type NamedElementType = React.ElementType & {
+  displayName?: string;
+  name?: string;
+};
+
+const describeElement = (node: React.ReactNode): string => {
+  if (typeof node === "string") {
+    return node.slice(0, 120);
+  }
+  if (!React.isValidElement(node)) {
+    return typeof node === "object" ? "[object]" : String(node);
+  }
+  const elementType = node.type as NamedElementType;
+  return elementType.displayName ?? elementType.name ?? String(elementType);
+};
+
 if (ENABLED) {
-  const originalOnly = (React.Children.only as any).bind(React.Children);
-  (React.Children as any).only = (child: any) => {
+  const childrenApi = React.Children as typeof React.Children;
+  const originalOnly = childrenApi.only.bind(React.Children) as typeof childrenApi.only;
+  childrenApi.only = (child: React.ReactNode) => {
     try {
       return originalOnly(child);
-    } catch (e) {
+    } catch (error: unknown) {
       // Print helpful info before rethrowing so the overlay shows this log
       // Try to show element type / displayName and a component stack
       // eslint-disable-next-line no-console
@@ -22,18 +39,13 @@ if (ENABLED) {
           "- conditional rendering returning false/null on one branch\n" +
           "- multiple siblings",
         {
-          childPreview:
-            typeof child === "string"
-              ? child.slice(0, 120)
-              : React.isValidElement(child)
-              ? (child.type as any)?.displayName || (child.type as any)?.name || child.type
-              : child,
+          childPreview: describeElement(child),
         }
       );
       // Show a JS stack (points to your component)
       // eslint-disable-next-line no-console
       console.trace("Stack where invalid child came from:");
-      throw e;
+      throw error;
     }
   };
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -72,18 +72,20 @@ export default function RootLayout({
     <html lang="fa-IR" dir="rtl" suppressHydrationWarning>
       <body className="min-h-screen bg-background font-sans antialiased">
         <ThemeProvider>
-          <div className="flex min-h-screen flex-col bg-background">
-            <Header navigation={navigation} />
-            <ConsentGate />
-            <main className="flex-1">{children}</main>
-            <JsonLd data={organizationJsonLd} />
-            <footer className="border-t border-border bg-card/50">
-              <div className="container flex flex-col gap-2 py-6 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-                <span>© {new Date().getFullYear()} بازارگاه فراخوان‌ها</span>
-                <span>ساخته شده برای اسپرینت صفر</span>
-              </div>
-            </footer>
-          </div>
+          <ClientProviders>
+            <div className="flex min-h-screen flex-col bg-background">
+              <Header navigation={navigation} />
+              <ConsentGate />
+              <main className="flex-1">{children}</main>
+              <JsonLd data={organizationJsonLd} />
+              <footer className="border-t border-border bg-card/50">
+                <div className="container flex flex-col gap-2 py-6 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+                  <span>© {new Date().getFullYear()} بازارگاه فراخوان‌ها</span>
+                  <span>ساخته شده برای اسپرینت صفر</span>
+                </div>
+              </footer>
+            </div>
+          </ClientProviders>
           <Toaster />
         </ThemeProvider>
       </body>


### PR DESCRIPTION
## Summary
- tighten the RootErrorBoundary and slot debug provider typings so they avoid `any`
- wrap the app layout with ClientProviders and remove unsafe casts in the button helper
- rebuild the billing test prisma mocks with explicit types instead of `any`

## Testing
- pnpm build *(fails: corepack could not download pnpm due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_690bb6a55b0c83278862dfa6ab769408