### PR TITLE
Fix billing server action directives

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/billing/actions.ts
+++ b/apps/web/app/(dashboard)/dashboard/billing/actions.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { revalidatePath } from "next/cache";
 
 import { getBillingDashboardData, startRenewalCheckout } from "@/lib/billing/dashboard";
@@ -34,6 +32,7 @@ type BillingActionResult<T> = { ok: true; data: T } | { ok: false; error: string
 type DashboardData = Awaited<ReturnType<typeof getBillingDashboardData>>;
 
 export async function refreshBillingDataAction(): Promise<BillingActionResult<DashboardData>> {
+  "use server";
   try {
     const userId = await ensureUserId();
     const data = await getBillingDashboardData(userId);
@@ -47,6 +46,7 @@ export async function refreshBillingDataAction(): Promise<BillingActionResult<Da
 export async function setCancelAtPeriodEndAction(
   flag: boolean,
 ): Promise<BillingActionResult<DashboardData>> {
+  "use server";
   let userId: string;
 
   try {
@@ -79,6 +79,7 @@ export async function setCancelAtPeriodEndAction(
 export async function renewSubscriptionAction(): Promise<
   BillingActionResult<StartCheckoutSessionResult>
 > {
+  "use server";
   let userId: string;
 
   try {


### PR DESCRIPTION
## Summary
- mark each billing dashboard server action with an explicit "use server" directive so Next.js treats them as server actions

## Testing
- not run (pnpm download blocked in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_690bd6b2545883278b32c5cc468b75c0