### PR TITLE
Guard checkout against unsupported currencies

### DIFF
--- a/apps/web/lib/billing/checkout.ts
+++ b/apps/web/lib/billing/checkout.ts
@@ -50,6 +50,10 @@ export async function startCheckoutSession({
   const fallbackPath = `/checkout/${session.id}/success`;
   const resolvedReturnUrl = sanitizeReturnUrl(returnUrl, fallbackPath);
 
+  if (price.currency !== "IRR") {
+    throw new Error("UNSUPPORTED_CURRENCY");
+  }
+
   const startResult = await adapter.start({
     sessionId: session.id,
     amount: price.amount,


### PR DESCRIPTION
## Summary
- throw a descriptive error when a checkout price is not denominated in IRR before invoking provider adapters

## Testing
- pnpm typecheck --filter @app/web *(fails: network restriction when installing pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_690d148f30a0832781029ae801ca1e74