### PR TITLE
Fix billing renewal action return URL

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/billing/actions.ts
+++ b/apps/web/app/(dashboard)/dashboard/billing/actions.ts
@@ -10,8 +10,6 @@ import {
 } from "@/lib/billing/subscriptionService";
 import { getServerAuthSession } from "@/lib/auth/session";
 import type { StartCheckoutSessionResult } from "@/lib/billing/checkout";
-import { env } from "@/lib/env";
-
 const DASHBOARD_PATH = "/dashboard/billing";
 
 const GENERIC_ERROR = "خطایی رخ داد. لطفاً دوباره تلاش کنید.";
@@ -92,7 +90,7 @@ export async function renewSubscriptionAction(): Promise<
     const result = await startRenewalCheckout({
       userId,
       provider: "zarinpal",
-      returnUrl: `${env.PUBLIC_BASE_URL}${DASHBOARD_PATH}?renewal=success`,
+      returnUrl: `${DASHBOARD_PATH}?renewal=success`,
     });
     emitBillingTelemetry("billing_renew_now_clicked", {
       userId,


### PR DESCRIPTION
## Summary
- stop importing the environment helper in the billing dashboard server actions
- rely on the dashboard route constant when building the renewal return URL so that `startCheckoutSession` can resolve it

## Testing
- Unable to run tests (pnpm install fails in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_690d18d701888327850193081b6178a7