### PR TITLE
Ensure storage smoke tests load env before storage config

### DIFF
--- a/apps/web/scripts/storage/env-loader.ts
+++ b/apps/web/scripts/storage/env-loader.ts
@@ -66,4 +66,10 @@ const loadStorageEnv = () => {
   initialized = true;
 };
 
+// Automatically load the storage environment variables as soon as this module
+// is imported so that downstream modules (for example the storage config
+// module) see the populated values during their module initialization. The
+// guard inside `loadStorageEnv` makes this call idempotent.
+loadStorageEnv();
+
 export { loadStorageEnv };

--- a/apps/web/scripts/storage/put-and-get-original.ts
+++ b/apps/web/scripts/storage/put-and-get-original.ts
@@ -1,12 +1,10 @@
 import { randomUUID } from "node:crypto";
 
-import { loadStorageEnv } from "./env-loader";
+import "./env-loader";
 import { cacheOriginal } from "../../lib/storage/headers";
 import { getOriginalKey } from "../../lib/storage/keys";
 import { head, putBuffer, remove } from "../../lib/storage/s3";
 import { resolveBucketForVisibility } from "../../lib/storage/visibility";
-
-loadStorageEnv();
 
 const run = async () => {
   const ownerId = randomUUID();

--- a/apps/web/scripts/storage/signed-url-expiry-check.ts
+++ b/apps/web/scripts/storage/signed-url-expiry-check.ts
@@ -1,10 +1,8 @@
 import { randomUUID } from "node:crypto";
 
-import { loadStorageEnv } from "./env-loader";
+import "./env-loader";
 import { storageConfig } from "../../lib/storage/config";
 import { getSignedGetUrl } from "../../lib/storage/signing";
-
-loadStorageEnv();
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/apps/web/scripts/storage/visibility-routing-check.ts
+++ b/apps/web/scripts/storage/visibility-routing-check.ts
@@ -1,8 +1,6 @@
-import { loadStorageEnv } from "./env-loader";
+import "./env-loader";
 import { storageConfig } from "../../lib/storage/config";
 import { resolveBucketForVisibility } from "../../lib/storage/visibility";
-
-loadStorageEnv();
 
 const run = () => {
   const publicBucket = resolveBucketForVisibility("public");


### PR DESCRIPTION
## Summary
- automatically load the storage smoke-test environment variables when the env-loader module is imported
- update the storage smoke test scripts to rely on the env-loader side effect so configuration is available during module initialization

## Testing
- pnpm --filter @app/web storage:smoke:original *(fails: proxy blocked download of pnpm 9.12.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915073ef3c883279f62e23c5345f9a6)