### PR TITLE
Handle async iterable S3 bodies safely

### DIFF
--- a/apps/web/lib/storage/s3.ts
+++ b/apps/web/lib/storage/s3.ts
@@ -97,7 +97,10 @@ const getStream = async (bucket: string, key: string) => {
   if (typeof body === "string" || body instanceof Uint8Array || Array.isArray(body)) {
     return Readable.from(body as Iterable<unknown>);
   }
-  return Readable.from(body as AsyncIterable<unknown>);
+  if (typeof (body as { [Symbol.asyncIterator]?: () => AsyncIterator<unknown> })[Symbol.asyncIterator] === "function") {
+    return Readable.from(body as AsyncIterable<unknown>);
+  }
+  throw new Error("Unsupported S3 object body type");
 };
 
 const put = async ({ bucket, key, body, contentType, cacheControl, acl }: PutInput) => {


### PR DESCRIPTION
## Summary
- add an explicit type guard for async-iterable S3 response bodies to avoid unsafe casts
- throw a clear error when an unexpected body type is encountered

## Testing
- `pnpm --filter @app/web typecheck` *(fails: pnpm download blocked by sandbox networking restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915142184408327b6bea73ecd412362)