### PR TITLE
Fix worker typecheck configuration and event typings

### DIFF
--- a/apps/worker/src/queues/mediaTranscode.monitor.ts
+++ b/apps/worker/src/queues/mediaTranscode.monitor.ts
@@ -1,4 +1,19 @@
-import type { CompletedEvent, FailedEvent, QueueEvents, StalledEvent } from "bullmq";
+import type { QueueEvents } from "bullmq";
+
+type CompletedEvent = {
+  jobId: string | number;
+  returnvalue?: unknown;
+};
+
+type FailedEvent = {
+  jobId: string | number;
+  failedReason?: string;
+  prev?: string | number | null;
+};
+
+type StalledEvent = {
+  jobId: string | number;
+};
 
 import { logger } from "../lib/logger";
 import { createQueueEvents } from "../lib/queue-connection";
@@ -43,7 +58,7 @@ const handleStalled = (event: StalledEvent) => {
 };
 
 const handleError = (queueEvents: QueueEvents) => {
-  queueEvents.on("error", (error) => {
+  queueEvents.on("error", (error: Error) => {
     logger.error("queue", "Queue events error", {
       queue: MEDIA_TRANSCODE_QUEUE_NAME,
       message: error.message,

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
     "module": "CommonJS",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- remove the worker TypeScript rootDir restriction so shared packages resolve correctly
- inline the queue event payload types and annotate the error listener

## Testing
- pnpm --filter @app/worker typecheck *(fails: unable to download pnpm binary in CI sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916a632bed88327bd788b11f1a2eb37)