### PR TITLE
feat(worker): implement ffmpeg-based transcode pipeline

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,13 +6,18 @@
     "dev": "tsx src/index.ts",
     "queue:enqueue-sample": "tsx scripts/enqueue-sample-video.ts",
     "queue:drain": "tsx scripts/queue-drain.ts",
+    "transcode:media": "tsx scripts/transcode-real-asset.ts",
+    "probe:media": "tsx scripts/probe-only.ts",
     "build": "tsup src/index.ts --format cjs --dts",
     "start": "node dist/index.js",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.930.0",
+    "@prisma/client": "6.16.3",
     "bullmq": "^5.7.9",
+    "execa": "^9.4.0",
     "ioredis": "^5.4.1",
     "zod": "^3.23.8",
     "@acme/contracts": "workspace:*"

--- a/apps/worker/scripts/probe-only.ts
+++ b/apps/worker/scripts/probe-only.ts
@@ -1,0 +1,75 @@
+import { extname } from "node:path";
+
+import { MediaType } from "@prisma/client";
+
+import { logger } from "../src/lib/logger";
+import { prisma } from "../src/lib/prisma";
+import { cleanupPath, createTempFile } from "../src/lib/tmp";
+import { probeMedia } from "../src/services/ffprobe";
+import { storageConfig } from "../src/storage/config";
+import { downloadToFile } from "../src/storage/io";
+
+const resolveMediaId = () => {
+  const fromEnv = process.env.MEDIA_ID?.trim();
+  if (fromEnv && fromEnv.length > 0) {
+    return fromEnv;
+  }
+  const fromArg = process.argv[2]?.trim();
+  if (fromArg && fromArg.length > 0) {
+    return fromArg;
+  }
+  return null;
+};
+
+const safeCleanup = async (path: string | null) => {
+  if (!path) {
+    return;
+  }
+  try {
+    await cleanupPath(path);
+  } catch (error) {
+    logger.warn("script", "Failed to cleanup temporary file", {
+      path,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+const main = async () => {
+  const mediaId = resolveMediaId();
+  if (!mediaId) {
+    throw new Error("MEDIA_ID is required via environment variable or CLI argument");
+  }
+
+  const media = await prisma.mediaAsset.findUnique({ where: { id: mediaId } });
+  if (!media) {
+    throw new Error(`Media asset ${mediaId} not found`);
+  }
+  if (media.type !== MediaType.video) {
+    throw new Error(`Media asset ${mediaId} is not a video`);
+  }
+
+  let tempPath: string | null = null;
+  try {
+    const sourceExt = extname(media.sourceKey) || ".mp4";
+    tempPath = await createTempFile("media-probe", sourceExt);
+    await downloadToFile(storageConfig.privateBucket, media.sourceKey, tempPath);
+    const metadata = await probeMedia(tempPath);
+    logger.info("script", "Probe metadata", { mediaAssetId: mediaId, metadata });
+  } finally {
+    await safeCleanup(tempPath);
+  }
+};
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (error) => {
+    logger.error("script", "Failed to probe media asset", {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    await prisma.$disconnect().catch(() => {});
+    process.exitCode = 1;
+  });

--- a/apps/worker/scripts/transcode-real-asset.ts
+++ b/apps/worker/scripts/transcode-real-asset.ts
@@ -1,0 +1,84 @@
+import { TranscodeJobStatus } from "@prisma/client";
+
+import { config } from "../src/config";
+import { logger } from "../src/lib/logger";
+import { prisma } from "../src/lib/prisma";
+import { createQueue } from "../src/lib/queue-connection";
+import { MEDIA_TRANSCODE_QUEUE_NAME } from "../src/queues/mediaTranscode.constants";
+import type { MediaTranscodeJobData } from "../src/queues/mediaTranscode.types";
+
+const resolveMediaId = () => {
+  const fromEnv = process.env.MEDIA_ID?.trim();
+  if (fromEnv && fromEnv.length > 0) {
+    return fromEnv;
+  }
+  const fromArg = process.argv[2]?.trim();
+  if (fromArg && fromArg.length > 0) {
+    return fromArg;
+  }
+  return null;
+};
+
+const main = async () => {
+  const mediaId = resolveMediaId();
+  if (!mediaId) {
+    throw new Error("MEDIA_ID is required via environment variable or CLI argument");
+  }
+
+  const media = await prisma.mediaAsset.findUnique({ where: { id: mediaId } });
+  if (!media) {
+    throw new Error(`Media asset ${mediaId} not found`);
+  }
+
+  const latestJob = await prisma.transcodeJob.findFirst({
+    where: { mediaAssetId: mediaId },
+    orderBy: { attempt: "desc" },
+  });
+  const nextAttempt = (latestJob?.attempt ?? 0) + 1;
+
+  const createdJob = await prisma.transcodeJob.create({
+    data: {
+      mediaAssetId: mediaId,
+      attempt: nextAttempt,
+      status: TranscodeJobStatus.queued,
+    },
+  });
+
+  const queue = createQueue(MEDIA_TRANSCODE_QUEUE_NAME);
+  try {
+    const payload: MediaTranscodeJobData = { mediaAssetId: mediaId, attempt: nextAttempt };
+    const job = await queue.add(
+      MEDIA_TRANSCODE_QUEUE_NAME,
+      payload,
+      {
+        jobId: `${MEDIA_TRANSCODE_QUEUE_NAME}:${mediaId}:${nextAttempt}`,
+        attempts: config.MEDIA_TRANSCODE_MAX_ATTEMPTS,
+        backoff: { type: "exponential", delay: config.MEDIA_TRANSCODE_BACKOFF_MS },
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
+    logger.info("script", "Enqueued media transcode job", {
+      queue: MEDIA_TRANSCODE_QUEUE_NAME,
+      jobId: job.id,
+      mediaAssetId: mediaId,
+      attempt: nextAttempt,
+      transcodeJobId: createdJob.id,
+    });
+  } finally {
+    await queue.close();
+  }
+};
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (error) => {
+    logger.error("script", "Failed to enqueue media transcode job", {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    await prisma.$disconnect().catch(() => {});
+    process.exitCode = 1;
+  });

--- a/apps/worker/src/config.transcode.ts
+++ b/apps/worker/src/config.transcode.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+const variantSchema = z.object({
+  name: z.string().min(1),
+  width: z.coerce.number().int().positive(),
+  height: z.coerce.number().int().positive(),
+  videoBitrateKbps: z.coerce.number().int().positive(),
+  audioBitrateKbps: z.coerce.number().int().positive(),
+});
+
+type VariantConfig = z.infer<typeof variantSchema>;
+
+const parseVariants = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed;
+    } catch (error) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "HLS_VARIANTS must be valid JSON" });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(variantSchema).min(1));
+
+const schema = z.object({
+  FFMPEG_PATH: z.string().min(1),
+  FFPROBE_PATH: z.string().min(1),
+  HLS_SEGMENT_DURATION_SEC: z.coerce.number().positive(),
+  HLS_PLAYLIST_NAME: z.string().min(1),
+  HLS_VARIANTS: parseVariants,
+  HLS_POSTER_TIME_FRACTION: z.coerce.number().min(0).max(1),
+});
+
+const defaultVariants: VariantConfig[] = [
+  { name: "240p", width: 426, height: 240, videoBitrateKbps: 400, audioBitrateKbps: 64 },
+  { name: "480p", width: 854, height: 480, videoBitrateKbps: 800, audioBitrateKbps: 96 },
+  { name: "720p", width: 1280, height: 720, videoBitrateKbps: 2500, audioBitrateKbps: 128 },
+];
+
+const raw = schema.parse({
+  FFMPEG_PATH: process.env.FFMPEG_PATH ?? "ffmpeg",
+  FFPROBE_PATH: process.env.FFPROBE_PATH ?? "ffprobe",
+  HLS_SEGMENT_DURATION_SEC: process.env.HLS_SEGMENT_DURATION_SEC ?? "6",
+  HLS_PLAYLIST_NAME: process.env.HLS_PLAYLIST_NAME ?? "index.m3u8",
+  HLS_VARIANTS: process.env.HLS_VARIANTS ?? JSON.stringify(defaultVariants),
+  HLS_POSTER_TIME_FRACTION: process.env.HLS_POSTER_TIME_FRACTION ?? "0.5",
+});
+
+const transcodeConfig = {
+  ffmpegPath: raw.FFMPEG_PATH,
+  ffprobePath: raw.FFPROBE_PATH,
+  segmentDurationSec: raw.HLS_SEGMENT_DURATION_SEC,
+  playlistName: raw.HLS_PLAYLIST_NAME,
+  variants: raw.HLS_VARIANTS,
+  posterTimeFraction: raw.HLS_POSTER_TIME_FRACTION,
+};
+
+export { transcodeConfig };
+export type { VariantConfig };

--- a/apps/worker/src/lib/prisma.ts
+++ b/apps/worker/src/lib/prisma.ts
@@ -1,0 +1,43 @@
+import { PrismaClient } from "@prisma/client";
+
+const resolveDatabaseUrl = (url: string) => {
+  try {
+    const parsed = new URL(url);
+    const schema = parsed.searchParams.get("schema");
+    if (!schema || schema.trim().length === 0) {
+      parsed.searchParams.set("schema", "public");
+      return parsed.toString();
+    }
+    return url;
+  } catch (error) {
+    return url;
+  }
+};
+
+const databaseUrl = (() => {
+  const value = process.env.DATABASE_URL;
+  if (!value || value.trim().length === 0) {
+    throw new Error("DATABASE_URL is required");
+  }
+  return resolveDatabaseUrl(value);
+})();
+
+const createClient = () => {
+  return new PrismaClient({
+    datasources: {
+      db: {
+        url: databaseUrl,
+      },
+    },
+  });
+};
+
+const globalForPrisma = globalThis as unknown as { mediaWorkerPrisma?: PrismaClient };
+
+const prisma = globalForPrisma.mediaWorkerPrisma ?? createClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.mediaWorkerPrisma = prisma;
+}
+
+export { prisma };

--- a/apps/worker/src/lib/tmp.ts
+++ b/apps/worker/src/lib/tmp.ts
@@ -1,0 +1,38 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const normalizeExt = (ext: string) => {
+  const trimmed = ext.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed.startsWith(".")) {
+    return trimmed;
+  }
+  return `.${trimmed}`;
+};
+
+const createTempFile = async (prefix: string, ext: string) => {
+  const suffix = randomBytes(8).toString("hex");
+  const filePath = join(tmpdir(), `${prefix}-${Date.now()}-${suffix}${normalizeExt(ext)}`);
+  await mkdir(dirname(filePath), { recursive: true });
+  return filePath;
+};
+
+const createTempDir = async (prefix: string) => {
+  return mkdtemp(join(tmpdir(), `${prefix}-`));
+};
+
+const cleanupPath = async (path: string) => {
+  try {
+    await rm(path, { recursive: true, force: true });
+  } catch (error) {
+    if ((error as { code?: string }).code !== "ENOENT") {
+      throw error;
+    }
+  }
+};
+
+export { cleanupPath, createTempDir, createTempFile };

--- a/apps/worker/src/services/ffprobe.ts
+++ b/apps/worker/src/services/ffprobe.ts
@@ -1,0 +1,86 @@
+import { execa } from "execa";
+
+import { transcodeConfig } from "../config.transcode";
+
+type ProbeStream = {
+  codec_type?: string;
+  codec_name?: string;
+  codec_long_name?: string;
+  width?: number;
+  height?: number;
+  duration?: string | number;
+  bit_rate?: string | number;
+};
+
+type ProbeFormat = {
+  duration?: string;
+  bit_rate?: string;
+};
+
+type ProbeResponse = {
+  streams?: ProbeStream[];
+  format?: ProbeFormat;
+};
+
+type MediaMetadata = {
+  durationSec: number;
+  width: number;
+  height: number;
+  videoCodec: string;
+  audioCodec?: string;
+  bitrateKbps?: number;
+};
+
+const parseNumber = (value: unknown) => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+};
+
+const probeMedia = async (inputPath: string): Promise<MediaMetadata> => {
+  const { stdout } = await execa(transcodeConfig.ffprobePath, [
+    "-v",
+    "error",
+    "-print_format",
+    "json",
+    "-show_streams",
+    "-show_format",
+    inputPath,
+  ]);
+  const parsed = JSON.parse(stdout) as ProbeResponse;
+  const streams = parsed.streams ?? [];
+  const videoStream = streams.find((stream) => stream.codec_type === "video");
+  if (!videoStream) {
+    throw new Error("No video stream found in media");
+  }
+  const audioStream = streams.find((stream) => stream.codec_type === "audio");
+  const durationFromFormat = parseNumber(parsed.format?.duration);
+  const durationFromVideo = parseNumber(videoStream.duration);
+  const durationSec = durationFromFormat ?? durationFromVideo;
+  if (!durationSec || durationSec <= 0) {
+    throw new Error("Unable to determine media duration");
+  }
+  const width = parseNumber(videoStream.width);
+  const height = parseNumber(videoStream.height);
+  if (!width || !height) {
+    throw new Error("Unable to determine video dimensions");
+  }
+  const bitrateBits = parseNumber(parsed.format?.bit_rate) ?? parseNumber(videoStream.bit_rate);
+  const bitrateKbps = bitrateBits ? bitrateBits / 1000 : undefined;
+  return {
+    durationSec,
+    width,
+    height,
+    videoCodec: videoStream.codec_name ?? videoStream.codec_long_name ?? "unknown",
+    audioCodec: audioStream?.codec_name ?? audioStream?.codec_long_name ?? undefined,
+    bitrateKbps,
+  };
+};
+
+export type { MediaMetadata };
+export { probeMedia };

--- a/apps/worker/src/services/hls-transcode.ts
+++ b/apps/worker/src/services/hls-transcode.ts
@@ -1,0 +1,122 @@
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+import { execa } from "execa";
+
+import { transcodeConfig, type VariantConfig } from "../config.transcode";
+
+type HlsVariantOutput = {
+  name: string;
+  playlistPath: string;
+  segmentPaths: string[];
+};
+
+type HlsResult = {
+  manifestPath: string;
+  variantOutputs: HlsVariantOutput[];
+};
+
+const toPosixPath = (value: string) => value.replace(/\\/g, "/");
+
+const buildCommandArgs = (
+  inputPath: string,
+  variant: VariantConfig,
+  segmentDurationSec: number,
+  playlistPath: string,
+  segmentPattern: string,
+) => {
+  const videoBitrate = Math.max(variant.videoBitrateKbps, 1);
+  const audioBitrate = Math.max(variant.audioBitrateKbps, 1);
+  const maxRate = Math.max(Math.round(videoBitrate * 1.2), videoBitrate + 1);
+  const bufSize = Math.max(videoBitrate * 2, videoBitrate + 1);
+  return [
+    "-y",
+    "-i",
+    inputPath,
+    "-vf",
+    `scale=w=${variant.width}:h=${variant.height}:force_original_aspect_ratio=decrease:force_divisible_by=2`,
+    "-c:v",
+    "h264",
+    "-profile:v",
+    "main",
+    "-preset",
+    "veryfast",
+    "-b:v",
+    `${videoBitrate}k`,
+    "-maxrate",
+    `${maxRate}k`,
+    "-bufsize",
+    `${bufSize}k`,
+    "-sc_threshold",
+    "0",
+    "-c:a",
+    "aac",
+    "-b:a",
+    `${audioBitrate}k`,
+    "-ac",
+    "2",
+    "-ar",
+    "48000",
+    "-hls_time",
+    `${segmentDurationSec}`,
+    "-hls_playlist_type",
+    "vod",
+    "-hls_segment_filename",
+    segmentPattern,
+    "-hls_flags",
+    "independent_segments",
+    "-hls_list_size",
+    "0",
+    "-f",
+    "hls",
+    playlistPath,
+  ];
+};
+
+const transcodeToHls = async (
+  inputPath: string,
+  outputDir: string,
+  playlistName: string,
+  variants: VariantConfig[],
+  segmentDurationSec: number,
+): Promise<HlsResult> => {
+  await mkdir(outputDir, { recursive: true });
+  const variantOutputs: HlsVariantOutput[] = [];
+  for (const variant of variants) {
+    const variantDir = join(outputDir, `v${variant.name}`);
+    await mkdir(variantDir, { recursive: true });
+    const playlistPath = join(variantDir, "index.m3u8");
+    const segmentPattern = join(variantDir, "segment_%05d.ts");
+    await execa(transcodeConfig.ffmpegPath, buildCommandArgs(inputPath, variant, segmentDurationSec, playlistPath, segmentPattern));
+    const files = await readdir(variantDir);
+    const segmentPaths = files
+      .filter((file) => file.endsWith(".ts"))
+      .map((file) => join(variantDir, file))
+      .sort();
+    variantOutputs.push({
+      name: variant.name,
+      playlistPath,
+      segmentPaths,
+    });
+  }
+  const manifestPath = join(outputDir, playlistName);
+  const manifestLines = ["#EXTM3U", "#EXT-X-VERSION:3", "#EXT-X-INDEPENDENT-SEGMENTS"];
+  variants.forEach((variant, index) => {
+    const variantOutput = variantOutputs[index];
+    if (!variantOutput) {
+      throw new Error(`Missing HLS output for variant ${variant.name}`);
+    }
+    const bandwidth = Math.max(Math.round((variant.videoBitrateKbps + variant.audioBitrateKbps) * 1000), 1);
+    const averageBandwidth = Math.max(Math.round(bandwidth * 0.95), 1);
+    const relativePath = toPosixPath(relative(outputDir, variantOutput.playlistPath));
+    manifestLines.push(
+      `#EXT-X-STREAM-INF:BANDWIDTH=${bandwidth},AVERAGE-BANDWIDTH=${averageBandwidth},RESOLUTION=${variant.width}x${variant.height},CODECS="avc1.4d401f,mp4a.40.2"`,
+    );
+    manifestLines.push(relativePath);
+  });
+  await writeFile(manifestPath, `${manifestLines.join("\n")}\n`);
+  return { manifestPath, variantOutputs };
+};
+
+export type { HlsResult };
+export { transcodeToHls };

--- a/apps/worker/src/services/poster.ts
+++ b/apps/worker/src/services/poster.ts
@@ -1,0 +1,41 @@
+import { execa } from "execa";
+
+import { transcodeConfig } from "../config.transcode";
+
+const clampPosterTime = (durationSec: number, posterTimeFraction: number) => {
+  const safeDuration = Number.isFinite(durationSec) && durationSec > 0 ? durationSec : 1;
+  const raw = safeDuration * posterTimeFraction;
+  const maxTimestamp = Math.max(safeDuration - 1, 1);
+  const minTimestamp = Math.min(1, maxTimestamp);
+  let timestamp = Math.min(Math.max(raw, minTimestamp), maxTimestamp);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) {
+    timestamp = Math.min(Math.max(safeDuration / 2, minTimestamp), maxTimestamp);
+  }
+  if (timestamp >= safeDuration) {
+    timestamp = Math.max(safeDuration - 0.1, minTimestamp);
+  }
+  return timestamp;
+};
+
+const generatePoster = async (
+  inputPath: string,
+  outputPath: string,
+  durationSec: number,
+  posterTimeFraction: number,
+): Promise<void> => {
+  const timestampSec = clampPosterTime(durationSec, posterTimeFraction);
+  await execa(transcodeConfig.ffmpegPath, [
+    "-y",
+    "-ss",
+    timestampSec.toFixed(2),
+    "-i",
+    inputPath,
+    "-frames:v",
+    "1",
+    "-q:v",
+    "2",
+    outputPath,
+  ]);
+};
+
+export { generatePoster };

--- a/apps/worker/src/storage/client.ts
+++ b/apps/worker/src/storage/client.ts
@@ -1,0 +1,15 @@
+import { S3Client } from "@aws-sdk/client-s3";
+
+import { storageConfig } from "./config";
+
+const s3 = new S3Client({
+  region: storageConfig.region,
+  credentials: {
+    accessKeyId: storageConfig.accessKey,
+    secretAccessKey: storageConfig.secretKey,
+  },
+  endpoint: storageConfig.endpoint,
+  forcePathStyle: storageConfig.forcePathStyle,
+});
+
+export { s3 };

--- a/apps/worker/src/storage/config.ts
+++ b/apps/worker/src/storage/config.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+type StorageConfig = {
+  endpoint?: string;
+  region: string;
+  accessKey: string;
+  secretKey: string;
+  publicBucket: string;
+  privateBucket: string;
+  forcePathStyle: boolean;
+};
+
+const schema = z.object({
+  S3_ENDPOINT: z.string().optional(),
+  S3_REGION: z.string().min(1),
+  S3_ACCESS_KEY: z.string().min(1),
+  S3_SECRET_KEY: z.string().min(1),
+  S3_PUBLIC_BUCKET: z.string().min(1),
+  S3_PRIVATE_BUCKET: z.string().min(1),
+  S3_FORCE_PATH_STYLE: z.string().optional(),
+});
+
+const raw = schema.parse({
+  S3_ENDPOINT: process.env.S3_ENDPOINT,
+  S3_REGION: process.env.S3_REGION,
+  S3_ACCESS_KEY: process.env.S3_ACCESS_KEY,
+  S3_SECRET_KEY: process.env.S3_SECRET_KEY,
+  S3_PUBLIC_BUCKET: process.env.S3_PUBLIC_BUCKET,
+  S3_PRIVATE_BUCKET: process.env.S3_PRIVATE_BUCKET,
+  S3_FORCE_PATH_STYLE: process.env.S3_FORCE_PATH_STYLE,
+});
+
+const endpoint = raw.S3_ENDPOINT?.trim();
+
+const storageConfig: StorageConfig = {
+  endpoint: endpoint && endpoint.length > 0 ? endpoint : undefined,
+  region: raw.S3_REGION,
+  accessKey: raw.S3_ACCESS_KEY,
+  secretKey: raw.S3_SECRET_KEY,
+  publicBucket: raw.S3_PUBLIC_BUCKET,
+  privateBucket: raw.S3_PRIVATE_BUCKET,
+  forcePathStyle: (() => {
+    const value = raw.S3_FORCE_PATH_STYLE?.trim().toLowerCase();
+    if (!value) {
+      return false;
+    }
+    return value === "true" || value === "1" || value === "yes";
+  })(),
+};
+
+export { storageConfig };
+export type { StorageConfig };

--- a/apps/worker/src/storage/headers.ts
+++ b/apps/worker/src/storage/headers.ts
@@ -1,0 +1,9 @@
+const cacheHlsSegment = () => "public, max-age=31536000, immutable";
+
+const cacheHlsManifest = () => "public, max-age=120";
+
+const cachePoster = () => "public, max-age=31536000, immutable";
+
+const cacheOriginal = () => "private, max-age=0, no-store";
+
+export { cacheHlsManifest, cacheHlsSegment, cacheOriginal, cachePoster };

--- a/apps/worker/src/storage/io.ts
+++ b/apps/worker/src/storage/io.ts
@@ -1,0 +1,89 @@
+import { createReadStream, createWriteStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+import type { ReadableStream as WebReadableStream } from "node:stream/web";
+
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { s3 } from "./client";
+
+type UploadOptions = {
+  bucket: string;
+  key: string;
+  contentType: string;
+  cacheControl?: string;
+};
+
+const toReadable = (body: unknown) => {
+  if (!body) {
+    throw new Error("S3 object body is empty");
+  }
+  if (body instanceof Readable) {
+    return body;
+  }
+  if (typeof (body as { getReader?: () => unknown }).getReader === "function") {
+    const reader = (body as WebReadableStream<Uint8Array>).getReader();
+    const iterator = {
+      async *[Symbol.asyncIterator]() {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) {
+            reader.releaseLock();
+            return;
+          }
+          yield value;
+        }
+      },
+    };
+    return Readable.from(iterator as AsyncIterable<Uint8Array>);
+  }
+  if (body instanceof Uint8Array || Array.isArray(body)) {
+    return Readable.from(body as Iterable<unknown>);
+  }
+  if (typeof body === "string") {
+    return Readable.from([body]);
+  }
+  if (typeof (body as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === "function") {
+    return Readable.from(body as AsyncIterable<unknown>);
+  }
+  throw new Error("Unsupported S3 object body type");
+};
+
+const downloadToFile = async (bucket: string, key: string, localPath: string) => {
+  const response = await s3.send(
+    new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    }),
+  );
+  const stream = toReadable(response.Body);
+  const writer = createWriteStream(localPath);
+  await pipeline(stream, writer);
+};
+
+const uploadFile = async ({ bucket, key, contentType, cacheControl }: UploadOptions, localPath: string) => {
+  const body = createReadStream(localPath);
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+      CacheControl: cacheControl,
+    }),
+  );
+};
+
+const uploadBuffer = async ({ bucket, key, contentType, cacheControl }: UploadOptions, buffer: Buffer) => {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: buffer,
+      ContentType: contentType,
+      CacheControl: cacheControl,
+    }),
+  );
+};
+
+export { downloadToFile, uploadBuffer, uploadFile };

--- a/apps/worker/src/storage/keys.ts
+++ b/apps/worker/src/storage/keys.ts
@@ -1,0 +1,37 @@
+const normalizeSegment = (value: string) => value.replace(/^\/+|\/+$/g, "");
+
+const normalizeExt = (ext: string) => {
+  const trimmed = ext.trim();
+  if (trimmed.startsWith(".")) {
+    return trimmed.slice(1);
+  }
+  return trimmed;
+};
+
+const joinKey = (...parts: string[]) =>
+  parts
+    .map((part) => normalizeSegment(part))
+    .filter((part) => part.length > 0)
+    .join("/");
+
+const getOriginalKey = (ownerUserId: string, mediaId: string, ext: string) => {
+  const safeExt = normalizeExt(ext);
+  if (safeExt.length === 0) {
+    throw new Error("File extension is required for original uploads");
+  }
+  return joinKey("uploads/originals", ownerUserId, `${mediaId}.${safeExt}`);
+};
+
+const getHlsManifestKey = (mediaId: string) => {
+  return joinKey("processed/hls", mediaId, "index.m3u8");
+};
+
+const getHlsVariantPrefix = (mediaId: string, variant: string) => {
+  return joinKey("processed/hls", mediaId, `v${variant}`);
+};
+
+const getPosterKey = (mediaId: string) => {
+  return joinKey("processed/posters", `${mediaId}.jpg`);
+};
+
+export { getHlsManifestKey, getHlsVariantPrefix, getOriginalKey, getPosterKey, joinKey };

--- a/apps/worker/src/storage/visibility.ts
+++ b/apps/worker/src/storage/visibility.ts
@@ -1,0 +1,12 @@
+import type { MediaVisibility } from "@prisma/client";
+
+import { storageConfig } from "./config";
+
+const resolveBucketForVisibility = (visibility: MediaVisibility) => {
+  if (visibility === "public") {
+    return storageConfig.publicBucket;
+  }
+  return storageConfig.privateBucket;
+};
+
+export { resolveBucketForVisibility };

--- a/apps/worker/src/workers/mediaTranscode.worker.ts
+++ b/apps/worker/src/workers/mediaTranscode.worker.ts
@@ -1,11 +1,26 @@
+import { basename, extname } from "node:path";
+import { stat } from "node:fs/promises";
+
 import type { Job } from "bullmq";
 import { Worker } from "bullmq";
+import { MediaStatus, MediaType, TranscodeJobStatus } from "@prisma/client";
 
 import { config } from "../config";
+import { transcodeConfig } from "../config.transcode";
 import { logger } from "../lib/logger";
+import { prisma } from "../lib/prisma";
 import { createWorkerConnection } from "../lib/queue-connection";
+import { cleanupPath, createTempDir, createTempFile } from "../lib/tmp";
 import { MEDIA_TRANSCODE_QUEUE_NAME } from "../queues/mediaTranscode.constants";
 import type { MediaTranscodeJobData } from "../queues/mediaTranscode.types";
+import { probeMedia } from "../services/ffprobe";
+import { transcodeToHls } from "../services/hls-transcode";
+import { generatePoster } from "../services/poster";
+import { storageConfig } from "../storage/config";
+import { cacheHlsManifest, cacheHlsSegment, cachePoster } from "../storage/headers";
+import { downloadToFile, uploadFile } from "../storage/io";
+import { getHlsManifestKey, getHlsVariantPrefix, getPosterKey, joinKey } from "../storage/keys";
+import { resolveBucketForVisibility } from "../storage/visibility";
 
 type MediaTranscodeJobResult = { mediaAssetId: string; attempt: number };
 
@@ -14,6 +29,21 @@ const calculateBackoff = (attemptsMade: number) => {
     return config.MEDIA_TRANSCODE_BACKOFF_MS;
   }
   return config.MEDIA_TRANSCODE_BACKOFF_MS * Math.pow(2, attemptsMade - 1);
+};
+
+const safeCleanup = async (path: string | null, label: string) => {
+  if (!path) {
+    return;
+  }
+  try {
+    await cleanupPath(path);
+  } catch (error) {
+    logger.warn("worker", "Failed to cleanup temporary path", {
+      path,
+      label,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
 };
 
 const processJob = async (job: Job<MediaTranscodeJobData>): Promise<MediaTranscodeJobResult> => {
@@ -29,8 +59,285 @@ const processJob = async (job: Job<MediaTranscodeJobData>): Promise<MediaTransco
     attempt,
     retryCount: job.attemptsMade,
   });
-  await new Promise((resolve) => setTimeout(resolve, 500));
-  return { mediaAssetId, attempt };
+
+  const variants = transcodeConfig.variants;
+  const segmentDurationSec = transcodeConfig.segmentDurationSec;
+
+  let media = await prisma.mediaAsset.findUnique({ where: { id: mediaAssetId } });
+  if (!media) {
+    throw new Error(`Media asset ${mediaAssetId} not found`);
+  }
+  if (media.type !== MediaType.video) {
+    throw new Error(`Unsupported media type ${media.type}`);
+  }
+
+  let transcodeJobRecord = await prisma.transcodeJob.findFirst({
+    where: { mediaAssetId, attempt },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (media.status === MediaStatus.ready && media.outputKey) {
+    if (transcodeJobRecord && transcodeJobRecord.status !== TranscodeJobStatus.done) {
+      const finishedAt = new Date();
+      await prisma.transcodeJob.update({
+        where: { id: transcodeJobRecord.id },
+        data: {
+          status: TranscodeJobStatus.done,
+          startedAt: transcodeJobRecord.startedAt ?? finishedAt,
+          finishedAt,
+          logs: {
+            skipped: true,
+            reason: "already-ready",
+          },
+        },
+      });
+    }
+    logger.info("worker", "Skipping transcode for already ready media", {
+      mediaAssetId,
+      jobId: job.id,
+    });
+    return { mediaAssetId, attempt };
+  }
+
+  const startTime = new Date();
+  const transactionResult = await prisma.$transaction(async (tx) => {
+    let activeJob = transcodeJobRecord;
+    if (activeJob) {
+      activeJob = await tx.transcodeJob.update({
+        where: { id: activeJob.id },
+        data: {
+          attempt,
+          status: TranscodeJobStatus.processing,
+          startedAt: startTime,
+          finishedAt: null,
+        },
+      });
+    } else {
+      activeJob = await tx.transcodeJob.create({
+        data: {
+          mediaAssetId,
+          attempt,
+          status: TranscodeJobStatus.processing,
+          startedAt: startTime,
+        },
+      });
+    }
+    const updatedMedia = await tx.mediaAsset.update({
+      where: { id: mediaAssetId },
+      data: {
+        status: MediaStatus.processing,
+        errorMessage: null,
+      },
+    });
+    return { activeJob, updatedMedia };
+  });
+
+  transcodeJobRecord = transactionResult.activeJob;
+  media = transactionResult.updatedMedia;
+
+  const sourceExt = extname(media.sourceKey);
+  let sourcePath: string | null = null;
+  let outputDir: string | null = null;
+  let posterPath: string | null = null;
+
+  try {
+    sourcePath = await createTempFile("media-source", sourceExt);
+    await downloadToFile(storageConfig.privateBucket, media.sourceKey, sourcePath);
+    const sourceStats = await stat(sourcePath);
+
+    const metadata = await probeMedia(sourcePath);
+
+    outputDir = await createTempDir("media-hls");
+    const hlsResult = await transcodeToHls(
+      sourcePath,
+      outputDir,
+      transcodeConfig.playlistName,
+      variants,
+      segmentDurationSec,
+    );
+
+    if (hlsResult.variantOutputs.length !== variants.length) {
+      throw new Error("Variant outputs mismatch");
+    }
+
+    posterPath = await createTempFile("media-poster", ".jpg");
+    await generatePoster(sourcePath, posterPath, metadata.durationSec, transcodeConfig.posterTimeFraction);
+
+    const manifestKey = getHlsManifestKey(media.id);
+    const posterKey = getPosterKey(media.id);
+    const outputBucket = resolveBucketForVisibility(media.visibility);
+
+    const manifestStat = await stat(hlsResult.manifestPath);
+    await uploadFile(
+      {
+        bucket: outputBucket,
+        key: manifestKey,
+        contentType: "application/vnd.apple.mpegurl",
+        cacheControl: cacheHlsManifest(),
+      },
+      hlsResult.manifestPath,
+    );
+
+    let totalOutputBytes = manifestStat.size;
+    const variantSummaries: Array<{
+      name: string;
+      width: number;
+      height: number;
+      videoBitrateKbps: number;
+      audioBitrateKbps: number;
+      playlistBytes: number;
+      segmentCount: number;
+      segmentBytes: number;
+    }> = [];
+
+    for (let index = 0; index < variants.length; index += 1) {
+      const variantConfig = variants[index];
+      const variantOutput = hlsResult.variantOutputs[index];
+      const variantPrefix = getHlsVariantPrefix(media.id, variantOutput.name);
+      const variantPlaylistKey = joinKey(variantPrefix, "index.m3u8");
+      const playlistStat = await stat(variantOutput.playlistPath);
+      await uploadFile(
+        {
+          bucket: outputBucket,
+          key: variantPlaylistKey,
+          contentType: "application/vnd.apple.mpegurl",
+          cacheControl: cacheHlsManifest(),
+        },
+        variantOutput.playlistPath,
+      );
+      totalOutputBytes += playlistStat.size;
+
+      let variantSegmentBytes = 0;
+      for (const segmentPath of variantOutput.segmentPaths) {
+        const segmentName = basename(segmentPath);
+        const segmentKey = joinKey(variantPrefix, segmentName);
+        const segmentStat = await stat(segmentPath);
+        await uploadFile(
+          {
+            bucket: outputBucket,
+            key: segmentKey,
+            contentType: "video/mp2t",
+            cacheControl: cacheHlsSegment(),
+          },
+          segmentPath,
+        );
+        variantSegmentBytes += segmentStat.size;
+      }
+      totalOutputBytes += variantSegmentBytes;
+      variantSummaries.push({
+        name: variantConfig.name,
+        width: variantConfig.width,
+        height: variantConfig.height,
+        videoBitrateKbps: variantConfig.videoBitrateKbps,
+        audioBitrateKbps: variantConfig.audioBitrateKbps,
+        playlistBytes: playlistStat.size,
+        segmentCount: variantOutput.segmentPaths.length,
+        segmentBytes: variantSegmentBytes,
+      });
+    }
+
+    const posterStat = await stat(posterPath);
+    await uploadFile(
+      {
+        bucket: outputBucket,
+        key: posterKey,
+        contentType: "image/jpeg",
+        cacheControl: cachePoster(),
+      },
+      posterPath,
+    );
+    totalOutputBytes += posterStat.size;
+
+    const durationSec = Math.max(Math.round(metadata.durationSec), 1);
+    const width = Math.max(Math.round(metadata.width), 1);
+    const height = Math.max(Math.round(metadata.height), 1);
+    const bitrate = metadata.bitrateKbps ? Math.max(Math.round(metadata.bitrateKbps), 1) : null;
+
+    const finishedAt = new Date();
+    await prisma.$transaction(async (tx) => {
+      await tx.mediaAsset.update({
+        where: { id: mediaAssetId },
+        data: {
+          status: MediaStatus.ready,
+          outputKey: manifestKey,
+          posterKey,
+          durationSec,
+          width,
+          height,
+          codec: metadata.videoCodec,
+          bitrate,
+          errorMessage: null,
+        },
+      });
+      await tx.transcodeJob.update({
+        where: { id: transcodeJobRecord.id },
+        data: {
+          status: TranscodeJobStatus.done,
+          finishedAt,
+          logs: {
+            ffprobe: metadata,
+            variants: variantSummaries,
+            manifestKey,
+            posterKey,
+            totalOutputBytes,
+            sourceBytes: sourceStats.size,
+            attempt,
+          },
+        },
+      });
+    });
+
+    logger.info("worker", "Media transcode job finished", {
+      mediaAssetId,
+      jobId: job.id,
+      manifestKey,
+      posterKey,
+    });
+
+    return { mediaAssetId, attempt };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const safeMessage = message.length > 500 ? `${message.slice(0, 497)}...` : message;
+    const failureLog: Record<string, unknown> = { error: safeMessage, attempt };
+    if (error instanceof Error && error.stack) {
+      failureLog.stack = error.stack;
+    }
+    const finishedAt = new Date();
+    try {
+      if (transcodeJobRecord) {
+        await prisma.transcodeJob.update({
+          where: { id: transcodeJobRecord.id },
+          data: {
+            status: TranscodeJobStatus.failed,
+            finishedAt,
+            logs: failureLog,
+          },
+        });
+      }
+      await prisma.mediaAsset.update({
+        where: { id: mediaAssetId },
+        data: {
+          status: MediaStatus.failed,
+          errorMessage: safeMessage,
+        },
+      });
+    } catch (updateError) {
+      logger.error("worker", "Failed to persist failure state", {
+        mediaAssetId,
+        message: updateError instanceof Error ? updateError.message : String(updateError),
+      });
+    }
+    logger.error("worker", "Media transcode job failed", {
+      mediaAssetId,
+      jobId: job.id,
+      message: safeMessage,
+    });
+    throw error;
+  } finally {
+    await safeCleanup(posterPath, "poster");
+    await safeCleanup(outputDir, "hls-output");
+    await safeCleanup(sourcePath, "source");
+  }
 };
 
 export const mediaTranscodeWorker = new Worker<MediaTranscodeJobData, MediaTranscodeJobResult>(

--- a/docs/video/phase5-transcode-pipeline.md
+++ b/docs/video/phase5-transcode-pipeline.md
@@ -1,0 +1,80 @@
+# Phase 5 – Transcode Pipeline
+
+## Overview
+The media worker now performs real FFmpeg processing for queued video assets. Each job downloads the original from the private bucket, probes it for metadata, generates multi-bitrate HLS outputs plus a poster image, uploads the derived files back to S3, and updates the database state.
+
+## Inputs
+- `MediaAsset` row with `status` `uploaded` or `processing`, `sourceKey`, and `visibility`.
+- Corresponding `TranscodeJob` row with `status` `queued`.
+- Job payload on the `media.transcode` BullMQ queue: `{ mediaAssetId, attempt }`.
+
+## Processing Steps
+1. Load the asset and job from Prisma. Skip if the asset is already `ready` with an `outputKey`.
+2. Transition the job to `processing` and mark the media asset as `processing`.
+3. Download the original video from the private bucket to a temporary file.
+4. Run `ffprobe` to collect duration, dimensions, codecs, and bitrate. Abort if the probe is invalid.
+5. Transcode the video to HLS using FFmpeg:
+   - Variants defined by `HLS_VARIANTS` env (defaults: 240p/480p/720p).
+   - Segment duration from `HLS_SEGMENT_DURATION_SEC` (default 6 seconds).
+   - Generates variant playlists under `v{name}/index.m3u8` and MPEG-TS segments.
+6. Generate a poster JPEG at the configured fraction of the video duration (`HLS_POSTER_TIME_FRACTION`, default 0.5).
+7. Upload outputs to S3:
+   - Manifest: `processed/hls/{mediaId}/index.m3u8` (cache-control `public, max-age=120`).
+   - Variant playlists: `processed/hls/{mediaId}/v{name}/index.m3u8`.
+   - Segments: `processed/hls/{mediaId}/v{name}/segment_*.ts` (cache-control `public, max-age=31536000, immutable`).
+   - Poster: `processed/posters/{mediaId}.jpg` (cache-control `public, max-age=31536000, immutable`).
+   - Visibility determines bucket selection via `resolveBucketForVisibility` (currently both default to the private bucket in dev).
+8. Update Prisma records inside a transaction:
+   - `MediaAsset`: status `ready`, set `outputKey`, `posterKey`, metadata fields, clear `errorMessage`.
+   - `TranscodeJob`: status `done`, `finishedAt`, and structured logs with probe data, variant byte counts, output keys, and totals.
+9. Remove temporary files/directories.
+
+On error, the worker updates `MediaAsset.status` to `failed`, stores a safe error message, marks the job `failed`, writes failure logs, and rethrows so BullMQ can retry.
+
+## S3 Layout
+```
+processed/hls/{mediaId}/index.m3u8
+processed/hls/{mediaId}/v{name}/index.m3u8
+processed/hls/{mediaId}/v{name}/segment_00000.ts
+processed/posters/{mediaId}.jpg
+```
+
+## Running the Pipeline Locally
+1. Start infrastructure:
+   ```bash
+   docker compose -f infra/docker-compose.dev.yml up -d
+   ```
+2. Start the worker:
+   ```bash
+   pnpm --filter apps/worker dev
+   ```
+3. Upload a video via the web app (existing script):
+   ```bash
+   pnpm --filter @app/web dev
+   pnpm --filter @app/web tsx apps/web/scripts/upload/init-signed-put.ts
+   ```
+   Copy the printed `mediaId`.
+4. Trigger transcoding for that asset:
+   ```bash
+   MEDIA_ID=<media-id> pnpm --filter apps/worker transcode:media
+   ```
+5. Observe worker logs for progress (download, probe, HLS, poster, uploads, DB updates).
+6. Verify database state (e.g., via Prisma studio or direct query) and call the status endpoint:
+   ```bash
+   curl http://localhost:3000/api/media/<media-id>/status
+   ```
+   Expect `status: "ready"`, populated metadata, and null `errorMessage`.
+
+## Failure & Retries
+- Any thrown error updates the job and media rows to `failed` with a concise message.
+- BullMQ retries use exponential backoff controlled by `MEDIA_TRANSCODE_BACKOFF_MS` and `MEDIA_TRANSCODE_MAX_ATTEMPTS`.
+- The worker is idempotent: if a job runs for an asset already marked `ready`, it skips processing and marks the job as complete.
+- Re-running `transcode:media` creates a new `TranscodeJob` record with an incremented attempt and enqueues another job.
+
+## Diagnostics
+- Detailed success metadata is stored in `TranscodeJob.logs`.
+- Failure diagnostics capture the error message (and stack in logs).
+- Temporary files live under the OS temp directory and are cleaned up after each job.
+- Additional tooling:
+  - `pnpm --filter apps/worker probe:media` downloads and probes an original without transcoding.
+  - `pnpm --filter apps/worker queue:drain` clears the BullMQ queue if needed.


### PR DESCRIPTION
## Summary
- add environment-driven transcode configuration along with ffprobe, HLS, and poster generation services
- introduce worker-side S3 utilities and rewrite the media transcode worker to perform real downloads, transcoding, uploads, and database updates
- provide developer scripts for probing/enqueuing media and document the full phase 5 pipeline

## Testing
- pnpm --filter apps/worker typecheck *(fails: registry access blocked in execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916a97abd1c83278f5aba7c1da147de)