### PR TITLE
Fix worker type resolution and Prisma log typing

### DIFF
--- a/apps/worker/src/workers/mediaTranscode.worker.ts
+++ b/apps/worker/src/workers/mediaTranscode.worker.ts
@@ -3,7 +3,7 @@ import { stat } from "node:fs/promises";
 
 import type { Job } from "bullmq";
 import { Worker } from "bullmq";
-import { MediaStatus, MediaType, TranscodeJobStatus } from "@prisma/client";
+import { MediaStatus, MediaType, Prisma, TranscodeJobStatus } from "@prisma/client";
 
 import { config } from "../config";
 import { transcodeConfig } from "../config.transcode";
@@ -298,10 +298,10 @@ const processJob = async (job: Job<MediaTranscodeJobData>): Promise<MediaTransco
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const safeMessage = message.length > 500 ? `${message.slice(0, 497)}...` : message;
-    const failureLog: Record<string, unknown> = { error: safeMessage, attempt };
-    if (error instanceof Error && error.stack) {
-      failureLog.stack = error.stack;
-    }
+    const failureLog: Prisma.JsonObject =
+      error instanceof Error && error.stack
+        ? { error: safeMessage, attempt, stack: error.stack }
+        : { error: safeMessage, attempt };
     const finishedAt = new Date();
     try {
       if (transcodeJobRecord) {

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "module": "CommonJS",
-    "moduleResolution": "node",
     "esModuleInterop": true,
     "types": ["node"],
     "incremental": false,


### PR DESCRIPTION
## Summary
- align the worker TypeScript configuration with the workspace defaults so bundler-style resolution can locate ESM dependencies
- ensure transcode failure logs use Prisma.JsonObject to satisfy the generated Prisma client types

## Testing
- npx tsc --project apps/worker/tsconfig.json --noEmit *(fails: missing generated Prisma client and external packages in the offline environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916af1deaf48327856a64a4719b7096)