### PR TITLE
Add hls.js dependency and refine video player typing

### DIFF
--- a/apps/web/components/media/VideoPlayer.tsx
+++ b/apps/web/components/media/VideoPlayer.tsx
@@ -17,6 +17,7 @@ export type VideoPlayerProps = {
 
 type HlsConstructor = typeof import("hls.js") extends { default: infer T } ? T : never;
 type HlsInstance = InstanceType<HlsConstructor>;
+type HlsErrorData = import("hls.js").ErrorData;
 
 const VideoPlayer = ({
   mediaId,
@@ -170,7 +171,7 @@ const VideoPlayer = ({
       instance.on(Hls.Events.MEDIA_ATTACHED, () => {
         instance.loadSource(resolvedManifestUrl);
       });
-      instance.on(Hls.Events.ERROR, (_event, data) => {
+      instance.on(Hls.Events.ERROR, (_event: unknown, data: HlsErrorData) => {
         if (data?.fatal) {
           setError("پخش ویدیو ممکن نیست.");
         }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
     "bullmq": "^5.43.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "hls.js": "^1.5.17",
     "ioredis": "^5.4.2",
     "lucide-react": "^0.446.0",
     "next": "15.0.0-canary.87",


### PR DESCRIPTION
## Summary
- add the missing `hls.js` dependency so the video player can be bundled and typed correctly
- tighten the HLS error handler typing to eliminate implicit `any` usage

## Testing
- `pnpm --filter @app/web typecheck` *(fails: Corepack cannot download pnpm because outbound network access is blocked in the execution environment)*
- `node_modules/.bin/tsc --project apps/web/tsconfig.json --noEmit` *(fails: Next.js type definitions are unavailable in the cached node_modules set in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c8ca293483279e87ff8d7ec5c645)