### PR TITLE
Add ambient types for hls.js in web app

### DIFF
--- a/apps/web/types/hls.js.d.ts
+++ b/apps/web/types/hls.js.d.ts
@@ -1,0 +1,31 @@
+declare module "hls.js" {
+  export interface HlsConfig {
+    enableWorker?: boolean;
+    [key: string]: unknown;
+  }
+
+  export interface ErrorData {
+    fatal?: boolean;
+    [key: string]: unknown;
+  }
+
+  export type HlsEventName = string;
+
+  export default class Hls {
+    constructor(config?: HlsConfig);
+    static isSupported(): boolean;
+    static Events: {
+      MEDIA_ATTACHED: HlsEventName;
+      ERROR: HlsEventName;
+      [key: string]: HlsEventName;
+    };
+
+    attachMedia(media: HTMLMediaElement): void;
+    loadSource(source: string): void;
+    on(
+      event: HlsEventName,
+      handler: (event: HlsEventName, data: ErrorData | undefined) => void,
+    ): void;
+    destroy(): void;
+  }
+}


### PR DESCRIPTION
## Summary
- add an ambient module declaration for hls.js so the web app's VideoPlayer can typecheck

## Testing
- pnpm --filter @app/web typecheck *(fails: blocked by registry proxy in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ca527de88327a60eefafe6ebbcf9)