### PR TITLE
Fix CDN config import in media script

### DIFF
--- a/apps/web/scripts/media/cdn-url-check.mts
+++ b/apps/web/scripts/media/cdn-url-check.mts
@@ -1,7 +1,19 @@
 import { PrismaClient } from "@prisma/client";
 
-import { mediaCdnConfig } from "../../lib/media/cdn-config";
+import type { MediaCdnConfig } from "../../lib/media/cdn-config";
+import * as mediaCdnConfigModule from "../../lib/media/cdn-config";
 import * as mediaUrls from "../../lib/media/urls";
+
+const mediaCdnConfig: MediaCdnConfig | undefined =
+  (mediaCdnConfigModule as Partial<{ mediaCdnConfig: MediaCdnConfig }>)
+    .mediaCdnConfig ??
+  (mediaCdnConfigModule as Partial<{ default: MediaCdnConfig }>).default;
+
+if (!mediaCdnConfig) {
+  throw new Error(
+    "mediaCdnConfig export missing from ../../lib/media/cdn-config",
+  );
+}
 
 const getPlaybackInfoForMedia: typeof mediaUrls.getPlaybackInfoForMedia =
   (mediaUrls as any).getPlaybackInfoForMedia ??


### PR DESCRIPTION
## Summary
- allow the CDN URL check script to consume either the named or default export from the CDN config module
- fail fast with a clear error message when no usable CDN config export is available

## Testing
- not run (network restrictions prevented pnpm execution)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ba26c0fc8327b355d841051605db)