### PR TITLE
Fix CDN playback script to import TypeScript sources

### DIFF
--- a/apps/web/lib/media/__tests__/urls.test.ts
+++ b/apps/web/lib/media/__tests__/urls.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/media/cdn-config", () => ({
+  mediaCdnConfig: {
+    cdnBaseUrl: "https://cdn.example.com/media",
+    originBaseUrl: "https://origin.example.com/media",
+    isSignedCdn: false,
+  },
+}));
+
+import { getPlaybackInfoForMedia } from "@/lib/media/urls";
+
+describe("getPlaybackInfoForMedia", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns CDN URLs for public media", () => {
+    const playback = getPlaybackInfoForMedia({
+      id: "example",
+      visibility: "public",
+      outputKey: "processed/hls/example/index.m3u8",
+      posterKey: "processed/posters/example.jpg",
+    } as any);
+
+    expect(playback.kind).toBe("public-direct");
+    expect(playback.manifestUrl).toBe(
+      "https://cdn.example.com/media/processed/hls/example/index.m3u8",
+    );
+    expect(playback.posterUrl).toBe(
+      "https://cdn.example.com/media/processed/posters/example.jpg",
+    );
+  });
+});

--- a/apps/web/scripts/media-player-smoke.mts
+++ b/apps/web/scripts/media-player-smoke.mts
@@ -1,5 +1,5 @@
 import { PrismaClient } from "@prisma/client";
-import * as mediaUrls from "../lib/media/urls";
+import * as mediaUrls from "../lib/media/urls.ts";
 
 const prisma = new PrismaClient();
 

--- a/apps/web/scripts/media/cdn-url-check.mts
+++ b/apps/web/scripts/media/cdn-url-check.mts
@@ -1,8 +1,8 @@
 import { PrismaClient } from "@prisma/client";
 
-import type { MediaCdnConfig } from "../../lib/media/cdn-config";
-import * as mediaCdnConfigModule from "../../lib/media/cdn-config";
-import * as mediaUrls from "../../lib/media/urls";
+import type { MediaCdnConfig } from "../../lib/media/cdn-config.ts";
+import * as mediaCdnConfigModule from "../../lib/media/cdn-config.ts";
+import * as mediaUrls from "../../lib/media/urls.ts";
 
 const mediaCdnConfig: MediaCdnConfig | undefined =
   (mediaCdnConfigModule as Partial<{ mediaCdnConfig: MediaCdnConfig }>)


### PR DESCRIPTION
## Summary
- force the CDN URL check and media player smoke scripts to import the TypeScript sources directly so stale JS builds cannot be used
- add a Vitest unit test to confirm getPlaybackInfoForMedia returns CDN-based URLs for public assets

## Testing
- not run (pnpm/vitest unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918cdd60b508327afe5c44ea78665a6)