### PR TITLE
Add admin media moderation dashboard and APIs

### DIFF
--- a/apps/web/app/admin/media/page.tsx
+++ b/apps/web/app/admin/media/page.tsx
@@ -1,0 +1,34 @@
+import { requireAdminSession } from "@/lib/auth/admin";
+import { AdminMediaStats } from "@/components/admin/media/AdminMediaStats";
+import { AdminMediaTable } from "@/components/admin/media/AdminMediaTable";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminMediaPage() {
+  await requireAdminSession();
+
+  return (
+    <div className="space-y-8" dir="rtl">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">مدیریت رسانه‌ها</h1>
+        <p className="text-sm text-muted-foreground">
+          تمامی ویدیوها و تصاویر بارگذاری‌شده را مشاهده، فیلتر و مدیریت کنید. وضعیت پردازش، نمایش و نتیجه بررسی هر رسانه در اینجا قابل دسترسی است.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">آمار کلی</h2>
+        <p className="text-sm text-muted-foreground">نمایی سریع از وضعیت پردازش و مدیریت محتوایی در روزهای اخیر.</p>
+        <AdminMediaStats />
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">لیست رسانه‌ها</h2>
+          <p className="text-sm text-muted-foreground">از فیلترها برای یافتن سریع رسانه‌ها استفاده کنید و با منوی عملیات، اقدامات لازم را انجام دهید.</p>
+        </div>
+        <AdminMediaTable />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/api/admin/media/[mediaId]/detail/route.ts
+++ b/apps/web/app/api/admin/media/[mediaId]/detail/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/admin";
+import { NO_STORE_HEADERS } from "@/lib/http";
+import { prisma } from "@/lib/prisma";
+
+type AdminMediaDetailResponse = {
+  id: string;
+  type: "image" | "video";
+  status: string;
+  visibility: "public" | "private";
+  moderationStatus: string;
+  moderationReason: string | null;
+  moderationReviewedAt: string | null;
+  moderationReviewedBy: { id: string; email: string | null } | null;
+  owner: { id: string; email: string | null };
+  sourceKey: string;
+  outputKey: string | null;
+  posterKey: string | null;
+  durationSec: number | null;
+  width: number | null;
+  height: number | null;
+  codec: string | null;
+  bitrate: number | null;
+  sizeBytes: number | null;
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastJob: {
+    id: string;
+    status: string;
+    attempt: number;
+    startedAt: string | null;
+    finishedAt: string | null;
+    logs: unknown;
+  } | null;
+};
+
+export async function GET(
+  request: NextRequest,
+  context: { params: { mediaId: string } },
+): Promise<NextResponse<AdminMediaDetailResponse>> {
+  await requireAdminSession();
+
+  const mediaId = context.params.mediaId;
+  if (!mediaId || mediaId.length === 0) {
+    return NextResponse.json({} as AdminMediaDetailResponse, {
+      status: 400,
+      headers: NO_STORE_HEADERS,
+    });
+  }
+
+  const media = await prisma.mediaAsset.findUnique({
+    where: { id: mediaId },
+    include: {
+      owner: { select: { id: true, email: true } },
+      moderationReviewedBy: { select: { id: true, email: true } },
+      transcodeJobs: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        select: {
+          id: true,
+          status: true,
+          attempt: true,
+          startedAt: true,
+          finishedAt: true,
+          logs: true,
+        },
+      },
+    },
+  });
+
+  if (!media) {
+    return NextResponse.json({} as AdminMediaDetailResponse, {
+      status: 404,
+      headers: NO_STORE_HEADERS,
+    });
+  }
+
+  const lastJob = media.transcodeJobs[0] ?? null;
+
+  const payload: AdminMediaDetailResponse = {
+    id: media.id,
+    type: media.type,
+    status: media.status,
+    visibility: media.visibility,
+    moderationStatus: media.moderationStatus,
+    moderationReason: media.moderationReason ?? null,
+    moderationReviewedAt: media.moderationReviewedAt
+      ? media.moderationReviewedAt.toISOString()
+      : null,
+    moderationReviewedBy: media.moderationReviewedBy
+      ? {
+          id: media.moderationReviewedBy.id,
+          email: media.moderationReviewedBy.email ?? null,
+        }
+      : null,
+    owner: {
+      id: media.owner.id,
+      email: media.owner.email ?? null,
+    },
+    sourceKey: media.sourceKey,
+    outputKey: media.outputKey ?? null,
+    posterKey: media.posterKey ?? null,
+    durationSec: media.durationSec ?? null,
+    width: media.width ?? null,
+    height: media.height ?? null,
+    codec: media.codec ?? null,
+    bitrate: media.bitrate ?? null,
+    sizeBytes: media.sizeBytes ? Number(media.sizeBytes) : null,
+    errorMessage: media.errorMessage ?? null,
+    createdAt: media.createdAt.toISOString(),
+    updatedAt: media.updatedAt.toISOString(),
+    lastJob: lastJob
+      ? {
+          id: lastJob.id,
+          status: lastJob.status,
+          attempt: lastJob.attempt,
+          startedAt: lastJob.startedAt ? lastJob.startedAt.toISOString() : null,
+          finishedAt: lastJob.finishedAt ? lastJob.finishedAt.toISOString() : null,
+          logs: lastJob.logs ?? null,
+        }
+      : null,
+  };
+
+  return NextResponse.json(payload, { headers: NO_STORE_HEADERS });
+}

--- a/apps/web/app/api/admin/media/actions/route.ts
+++ b/apps/web/app/api/admin/media/actions/route.ts
@@ -1,0 +1,196 @@
+import { MediaModerationStatus, MediaStatus, MediaVisibility, TranscodeJobStatus } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/admin";
+import { NO_STORE_HEADERS } from "@/lib/http";
+import { prisma } from "@/lib/prisma";
+import { enqueueTranscode } from "@/lib/queues/mediaTranscode.enqueue";
+import { resolveBucketForVisibility } from "@/lib/storage/visibility";
+import { remove } from "@/lib/storage/s3";
+
+type AdminMediaAction =
+  | { type: "REQUEUE_TRANSCODE"; mediaId: string }
+  | { type: "MARK_REJECTED"; mediaId: string; reason?: string }
+  | { type: "TOGGLE_VISIBILITY"; mediaId: string; visibility: "public" | "private" }
+  | { type: "DELETE_MEDIA"; mediaId: string };
+
+type ActionResponse = { ok: boolean; error?: string };
+
+const success = (): NextResponse<ActionResponse> => {
+  return NextResponse.json({ ok: true }, { headers: NO_STORE_HEADERS });
+};
+
+const failure = (status: number, error: string): NextResponse<ActionResponse> => {
+  return NextResponse.json({ ok: false, error }, { status, headers: NO_STORE_HEADERS });
+};
+
+const assertAdminId = (userId: string | undefined): string | null => {
+  if (!userId || userId.length === 0) {
+    return null;
+  }
+  return userId;
+};
+
+const handleRequeue = async (mediaId: string) => {
+  const result = await prisma.$transaction(async (tx) => {
+    const media = await tx.mediaAsset.findUnique({
+      where: { id: mediaId },
+      select: { id: true },
+    });
+    if (!media) {
+      return null;
+    }
+    const lastJob = await tx.transcodeJob.findFirst({
+      where: { mediaAssetId: mediaId },
+      orderBy: { attempt: "desc" },
+      select: { attempt: true },
+    });
+    const nextAttempt = (lastJob?.attempt ?? 0) + 1;
+    await tx.transcodeJob.create({
+      data: {
+        mediaAssetId: mediaId,
+        status: TranscodeJobStatus.queued,
+        attempt: nextAttempt,
+      },
+    });
+    await tx.mediaAsset.update({
+      where: { id: mediaId },
+      data: {
+        status: MediaStatus.processing,
+        errorMessage: null,
+      },
+    });
+    return nextAttempt;
+  });
+
+  if (result === null) {
+    return failure(404, "MEDIA_NOT_FOUND");
+  }
+
+  await enqueueTranscode(mediaId, result);
+  return success();
+};
+
+const handleReject = async (mediaId: string, reason: string | undefined, adminId: string) => {
+  const trimmedReason = reason?.trim() ?? "";
+  const now = new Date();
+  try {
+    await prisma.mediaAsset.update({
+      where: { id: mediaId },
+      data: {
+        moderationStatus: MediaModerationStatus.rejected,
+        moderationReason: trimmedReason.length > 0 ? trimmedReason : null,
+        moderationReviewedAt: now,
+        moderationReviewedById: adminId,
+        visibility: MediaVisibility.private,
+      },
+    });
+    return success();
+  } catch (error) {
+    return failure(404, "MEDIA_NOT_FOUND");
+  }
+};
+
+const handleToggleVisibility = async (mediaId: string, visibility: "public" | "private", adminId: string) => {
+  const now = new Date();
+  try {
+    await prisma.mediaAsset.update({
+      where: { id: mediaId },
+      data: {
+        visibility,
+        moderationStatus:
+          visibility === "public" ? MediaModerationStatus.approved : undefined,
+        moderationReason: visibility === "public" ? null : undefined,
+        moderationReviewedAt: now,
+        moderationReviewedById: adminId,
+      },
+    });
+    return success();
+  } catch (error) {
+    return failure(404, "MEDIA_NOT_FOUND");
+  }
+};
+
+const handleDelete = async (mediaId: string) => {
+  const media = await prisma.mediaAsset.findUnique({
+    where: { id: mediaId },
+    select: {
+      id: true,
+      sourceKey: true,
+      outputKey: true,
+      posterKey: true,
+      visibility: true,
+    },
+  });
+
+  if (!media) {
+    return failure(404, "MEDIA_NOT_FOUND");
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.transcodeJob.deleteMany({ where: { mediaAssetId: mediaId } });
+    await tx.mediaAsset.delete({ where: { id: mediaId } });
+  });
+
+  const deleteTasks: Array<Promise<unknown>> = [];
+  const privateBucket = resolveBucketForVisibility("private");
+  deleteTasks.push(
+    remove(privateBucket, media.sourceKey).catch(() => undefined),
+  );
+  if (media.outputKey) {
+    const bucket = resolveBucketForVisibility(media.visibility);
+    deleteTasks.push(remove(bucket, media.outputKey).catch(() => undefined));
+  }
+  if (media.posterKey) {
+    const bucket = resolveBucketForVisibility(media.visibility);
+    deleteTasks.push(remove(bucket, media.posterKey).catch(() => undefined));
+  }
+  await Promise.allSettled(deleteTasks);
+
+  return success();
+};
+
+export async function POST(request: NextRequest): Promise<NextResponse<ActionResponse>> {
+  const { user } = await requireAdminSession();
+
+  let payload: AdminMediaAction;
+  try {
+    payload = (await request.json()) as AdminMediaAction;
+  } catch (error) {
+    return failure(400, "INVALID_PAYLOAD");
+  }
+
+  if (!payload || typeof payload !== "object" || typeof payload.type !== "string") {
+    return failure(400, "INVALID_PAYLOAD");
+  }
+
+  if (!payload.mediaId || typeof payload.mediaId !== "string") {
+    return failure(400, "INVALID_MEDIA_ID");
+  }
+
+  switch (payload.type) {
+    case "REQUEUE_TRANSCODE":
+      return handleRequeue(payload.mediaId);
+    case "MARK_REJECTED": {
+      const adminId = assertAdminId(user.id);
+      if (!adminId) {
+        return failure(400, "ADMIN_ID_REQUIRED");
+      }
+      return handleReject(payload.mediaId, payload.reason, adminId);
+    }
+    case "TOGGLE_VISIBILITY": {
+      if (payload.visibility !== "public" && payload.visibility !== "private") {
+        return failure(400, "INVALID_VISIBILITY");
+      }
+      const adminId = assertAdminId(user.id);
+      if (!adminId) {
+        return failure(400, "ADMIN_ID_REQUIRED");
+      }
+      return handleToggleVisibility(payload.mediaId, payload.visibility, adminId);
+    }
+    case "DELETE_MEDIA":
+      return handleDelete(payload.mediaId);
+    default:
+      return failure(400, "UNKNOWN_ACTION");
+  }
+}

--- a/apps/web/app/api/admin/media/list/route.ts
+++ b/apps/web/app/api/admin/media/list/route.ts
@@ -1,0 +1,219 @@
+import { Buffer } from "node:buffer";
+
+import { MediaModerationStatus, MediaStatus, MediaType, type Prisma } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/admin";
+import { NO_STORE_HEADERS } from "@/lib/http";
+import { prisma } from "@/lib/prisma";
+
+type CursorValue = {
+  createdAt: Date;
+  id: string;
+};
+
+type AdminMediaListItem = {
+  id: string;
+  type: "image" | "video";
+  status: string;
+  visibility: "public" | "private";
+  moderationStatus: "pending" | "approved" | "rejected";
+  ownerUserId: string;
+  ownerEmail?: string | null;
+  createdAt: string;
+  durationSec?: number | null;
+  width?: number | null;
+  height?: number | null;
+  sizeBytes?: number | null;
+  errorMessage?: string | null;
+};
+
+type AdminMediaListResponse = {
+  items: AdminMediaListItem[];
+  nextCursor?: string | null;
+};
+
+const STATUS_VALUES = new Set<MediaStatus>([
+  MediaStatus.uploaded,
+  MediaStatus.processing,
+  MediaStatus.ready,
+  MediaStatus.failed,
+]);
+
+const TYPE_VALUES = new Set<MediaType>([MediaType.image, MediaType.video]);
+
+const MODERATION_OPTIONS = [
+  MediaModerationStatus.pending,
+  MediaModerationStatus.approved,
+  MediaModerationStatus.rejected,
+] as const;
+
+const MODERATION_VALUES = new Set<MediaModerationStatus>(MODERATION_OPTIONS);
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+const encodeCursor = (value: CursorValue): string => {
+  const payload = `${value.createdAt.toISOString()}::${value.id}`;
+  return Buffer.from(payload).toString("base64url");
+};
+
+const decodeCursor = (value: string): CursorValue | null => {
+  try {
+    const decoded = Buffer.from(value, "base64url").toString("utf8");
+    const [createdAtRaw, id] = decoded.split("::");
+    if (!createdAtRaw || !id) {
+      return null;
+    }
+    const createdAt = new Date(createdAtRaw);
+    if (Number.isNaN(createdAt.getTime())) {
+      return null;
+    }
+    return { createdAt, id };
+  } catch {
+    return null;
+  }
+};
+
+const buildCursorCondition = (cursor: CursorValue): Prisma.MediaAssetWhereInput => {
+  return {
+    OR: [
+      { createdAt: { lt: cursor.createdAt } },
+      {
+        AND: [
+          { createdAt: { equals: cursor.createdAt } },
+          { id: { lt: cursor.id } },
+        ],
+      },
+    ],
+  };
+};
+
+const parseLimit = (value: string | null): number => {
+  if (!value) {
+    return DEFAULT_LIMIT;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(parsed, MAX_LIMIT);
+};
+
+const toListItem = (
+  item: Prisma.MediaAssetGetPayload<{ include: { owner: { select: { email: true } } } }>,
+): AdminMediaListItem => {
+  return {
+    id: item.id,
+    type: item.type,
+    status: item.status,
+    visibility: item.visibility,
+    moderationStatus: item.moderationStatus,
+    ownerUserId: item.ownerUserId,
+    ownerEmail: item.owner?.email ?? null,
+    createdAt: item.createdAt.toISOString(),
+    durationSec: item.durationSec ?? null,
+    width: item.width ?? null,
+    height: item.height ?? null,
+    sizeBytes: item.sizeBytes ? Number(item.sizeBytes) : null,
+    errorMessage: item.errorMessage ?? null,
+  };
+};
+
+export async function GET(request: NextRequest): Promise<NextResponse<AdminMediaListResponse>> {
+  await requireAdminSession();
+
+  const { searchParams } = new URL(request.url);
+
+  const statusParam = searchParams.get("status");
+  const typeParam = searchParams.get("type");
+  const moderationParam = searchParams.get("moderation");
+  const userParam = searchParams.get("user");
+  const cursorParam = searchParams.get("cursor");
+  const limit = parseLimit(searchParams.get("limit"));
+
+  const where: Prisma.MediaAssetWhereInput = {};
+  const andConditions: Prisma.MediaAssetWhereInput[] = [];
+
+  if (statusParam) {
+    if (!STATUS_VALUES.has(statusParam as MediaStatus)) {
+      return NextResponse.json(
+        { items: [] },
+        { status: 400, headers: NO_STORE_HEADERS },
+      );
+    }
+    where.status = statusParam as MediaStatus;
+  }
+
+  if (typeParam) {
+    if (!TYPE_VALUES.has(typeParam as MediaType)) {
+      return NextResponse.json(
+        { items: [] },
+        { status: 400, headers: NO_STORE_HEADERS },
+      );
+    }
+    where.type = typeParam as MediaType;
+  }
+
+  if (moderationParam) {
+    if (!MODERATION_VALUES.has(moderationParam as MediaModerationStatus)) {
+      return NextResponse.json(
+        { items: [] },
+        { status: 400, headers: NO_STORE_HEADERS },
+      );
+    }
+    where.moderationStatus = moderationParam as MediaModerationStatus;
+  }
+
+  if (userParam && userParam.trim().length > 0) {
+    const query = userParam.trim();
+    andConditions.push({
+      OR: [
+        { ownerUserId: { contains: query } },
+        { owner: { email: { contains: query, mode: "insensitive" } } },
+      ],
+    });
+  }
+
+  if (cursorParam) {
+    const decoded = decodeCursor(cursorParam);
+    if (!decoded) {
+      return NextResponse.json(
+        { items: [] },
+        { status: 400, headers: NO_STORE_HEADERS },
+      );
+    }
+    andConditions.push(buildCursorCondition(decoded));
+  }
+
+  if (andConditions.length > 0) {
+    where.AND = andConditions;
+  }
+
+  const items = await prisma.mediaAsset.findMany({
+    where,
+    include: { owner: { select: { email: true } } },
+    orderBy: [
+      { createdAt: "desc" },
+      { id: "desc" },
+    ],
+    take: limit + 1,
+  });
+
+  const hasMore = items.length > limit;
+  const sliced = hasMore ? items.slice(0, limit) : items;
+  const responseItems = sliced.map(toListItem);
+  let nextCursor: string | null = null;
+  if (hasMore) {
+    const last = sliced[sliced.length - 1];
+    nextCursor = encodeCursor({ createdAt: last.createdAt, id: last.id });
+  }
+
+  return NextResponse.json(
+    {
+      items: responseItems,
+      nextCursor,
+    },
+    { headers: NO_STORE_HEADERS },
+  );
+}

--- a/apps/web/app/api/admin/media/metrics/route.ts
+++ b/apps/web/app/api/admin/media/metrics/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+import { requireAdminSession } from "@/lib/auth/admin";
+import { NO_STORE_HEADERS } from "@/lib/http";
+import { prisma } from "@/lib/prisma";
+import { getAdminMediaMetrics } from "@/lib/media/admin/metrics";
+
+export async function GET() {
+  await requireAdminSession();
+  const metrics = await getAdminMediaMetrics(prisma);
+  return NextResponse.json(metrics, { headers: NO_STORE_HEADERS });
+}

--- a/apps/web/components/admin/media/AdminMediaDetail.tsx
+++ b/apps/web/components/admin/media/AdminMediaDetail.tsx
@@ -1,0 +1,471 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Eye, EyeOff, RefreshCw, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+
+const statusLabels: Record<string, string> = {
+  uploaded: "آپلود شده",
+  processing: "در حال پردازش",
+  ready: "آماده",
+  failed: "ناموفق",
+};
+
+const statusVariants: Record<string, "secondary" | "warning" | "success" | "destructive"> = {
+  uploaded: "secondary",
+  processing: "warning",
+  ready: "success",
+  failed: "destructive",
+};
+
+const moderationLabels: Record<string, string> = {
+  pending: "در انتظار بررسی",
+  approved: "تایید شده",
+  rejected: "رد شده",
+};
+
+const moderationVariants: Record<string, "warning" | "success" | "destructive" | "secondary"> = {
+  pending: "warning",
+  approved: "success",
+  rejected: "destructive",
+};
+
+const visibilityLabels: Record<string, string> = {
+  public: "عمومی",
+  private: "خصوصی",
+};
+
+const visibilityVariants: Record<string, "success" | "secondary"> = {
+  public: "success",
+  private: "secondary",
+};
+
+const jobStatusLabels: Record<string, string> = {
+  queued: "در صف",
+  processing: "در حال پردازش",
+  done: "موفق",
+  failed: "ناموفق",
+};
+
+const jobStatusVariants: Record<string, "secondary" | "warning" | "success" | "destructive"> = {
+  queued: "secondary",
+  processing: "warning",
+  done: "success",
+  failed: "destructive",
+};
+
+const numberFormatter = new Intl.NumberFormat("fa-IR");
+const dateTimeFormatter = new Intl.DateTimeFormat("fa-IR", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const formatDuration = (value: number | null) => {
+  if (!value || value <= 0) {
+    return "نامشخص";
+  }
+  const minutes = Math.floor(value / 60);
+  const seconds = value % 60;
+  const minutesLabel = minutes > 0 ? `${numberFormatter.format(minutes)} دقیقه` : "";
+  const secondsLabel = `${numberFormatter.format(seconds)} ثانیه`;
+  return minutesLabel ? `${minutesLabel} و ${secondsLabel}` : secondsLabel;
+};
+
+const formatSize = (value: number | null) => {
+  if (!value || value <= 0) {
+    return "نامشخص";
+  }
+  const megabytes = value / (1024 * 1024);
+  const rounded = Math.round(megabytes * 10) / 10;
+  return `${numberFormatter.format(rounded)} مگابایت`;
+};
+
+const formatBitrate = (value: number | null) => {
+  if (!value || value <= 0) {
+    return "نامشخص";
+  }
+  const kbps = Math.round(value / 1000);
+  return `${numberFormatter.format(kbps)} کیلوبیت بر ثانیه`;
+};
+
+type MediaDetail = {
+  id: string;
+  type: "image" | "video";
+  status: string;
+  visibility: "public" | "private";
+  moderationStatus: string;
+  moderationReason: string | null;
+  moderationReviewedAt: string | null;
+  moderationReviewedBy: { id: string; email: string | null } | null;
+  owner: { id: string; email: string | null };
+  sourceKey: string;
+  outputKey: string | null;
+  posterKey: string | null;
+  durationSec: number | null;
+  width: number | null;
+  height: number | null;
+  codec: string | null;
+  bitrate: number | null;
+  sizeBytes: number | null;
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastJob: {
+    id: string;
+    status: string;
+    attempt: number;
+    startedAt: string | null;
+    finishedAt: string | null;
+    logs: unknown;
+  } | null;
+};
+
+type AdminMediaDetailProps = {
+  mediaId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onActionComplete?: () => void;
+};
+
+export function AdminMediaDetail({ mediaId, open, onOpenChange, onActionComplete }: AdminMediaDetailProps) {
+  const { toast } = useToast();
+  const [detail, setDetail] = useState<MediaDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState(false);
+  const [reason, setReason] = useState("");
+
+  const loadDetail = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!mediaId) {
+        setDetail(null);
+        return;
+      }
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/admin/media/${mediaId}/detail`, {
+          cache: "no-store",
+          signal,
+        });
+        if (!response.ok) {
+          throw new Error(response.status === 404 ? "رسانه یافت نشد." : "خطایی در دریافت اطلاعات رخ داد.");
+        }
+        const body = (await response.json()) as MediaDetail;
+        if (signal?.aborted) {
+          return;
+        }
+        setDetail(body);
+        setReason(body.moderationReason ?? "");
+      } catch (err) {
+        if (signal?.aborted) {
+          return;
+        }
+        setDetail(null);
+        setError(err instanceof Error ? err.message : "خطای ناشناخته رخ داد.");
+      } finally {
+        if (!signal?.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [mediaId],
+  );
+
+  useEffect(() => {
+    if (!open || !mediaId) {
+      setDetail(null);
+      setError(null);
+      setReason("");
+      return;
+    }
+    const controller = new AbortController();
+    loadDetail(controller.signal);
+    return () => {
+      controller.abort();
+    };
+  }, [open, mediaId, loadDetail]);
+
+  const handleAction = useCallback(
+    async (
+      payload: unknown,
+      successMessage: string,
+      options?: { skipReload?: boolean; onSuccess?: () => void },
+    ) => {
+      if (!mediaId) {
+        return;
+      }
+      setPendingAction(true);
+      try {
+        const response = await fetch("/api/admin/media/actions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        const body = (await response.json()) as { ok: boolean; error?: string };
+        if (!response.ok || !body.ok) {
+          throw new Error(body.error ?? "خطایی رخ داد.");
+        }
+        toast({ title: successMessage });
+        if (onActionComplete) {
+          onActionComplete();
+        }
+        if (!options?.skipReload) {
+          await loadDetail();
+        }
+        if (options?.onSuccess) {
+          options.onSuccess();
+        }
+      } catch (err) {
+        toast({ variant: "destructive", title: "خطا", description: err instanceof Error ? err.message : "عملیات ناموفق بود." });
+      } finally {
+        setPendingAction(false);
+      }
+    },
+    [loadDetail, mediaId, onActionComplete, toast],
+  );
+
+  const handleRequeue = () => {
+    handleAction({ type: "REQUEUE_TRANSCODE", mediaId }, "رسانه برای پردازش مجدد در صف قرار گرفت.");
+  };
+
+  const handleApprove = () => {
+    handleAction({ type: "TOGGLE_VISIBILITY", mediaId, visibility: "public" }, "رسانه تایید و عمومی شد.");
+  };
+
+  const handleToggleVisibility = () => {
+    if (!detail) {
+      return;
+    }
+    const nextVisibility = detail.visibility === "public" ? "private" : "public";
+    const message = nextVisibility === "public" ? "رسانه به حالت عمومی تغییر یافت." : "رسانه خصوصی شد.";
+    handleAction({ type: "TOGGLE_VISIBILITY", mediaId, visibility: nextVisibility }, message);
+  };
+
+  const handleReject = () => {
+    handleAction(
+      { type: "MARK_REJECTED", mediaId, reason },
+      "رسانه با موفقیت رد شد.",
+    );
+  };
+
+  const handleDelete = () => {
+    if (!mediaId) {
+      return;
+    }
+    const confirmed = window.confirm("آیا از حذف این رسانه اطمینان دارید؟");
+    if (!confirmed) {
+      return;
+    }
+    handleAction(
+      { type: "DELETE_MEDIA", mediaId },
+      "رسانه حذف شد.",
+      {
+        skipReload: true,
+        onSuccess: () => onOpenChange(false),
+      },
+    );
+  };
+
+  const renderLogs = (logs: unknown) => {
+    if (logs === null || logs === undefined) {
+      return "اطلاعاتی ثبت نشده است.";
+    }
+    if (typeof logs === "string") {
+      return logs;
+    }
+    try {
+      return JSON.stringify(logs, null, 2);
+    } catch (error) {
+      return String(logs);
+    }
+  };
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="space-y-4" dir="rtl">
+          <Skeleton className="h-6 w-1/4" />
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      );
+    }
+    if (error) {
+      return <p className="text-sm text-destructive">{error}</p>;
+    }
+    if (!detail) {
+      return <p className="text-sm text-muted-foreground">اطلاعاتی برای نمایش وجود ندارد.</p>;
+    }
+    return (
+      <div className="space-y-6 text-sm" dir="rtl">
+        <section className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={statusVariants[detail.status] ?? "secondary"}>{statusLabels[detail.status] ?? detail.status}</Badge>
+            <Badge variant={moderationVariants[detail.moderationStatus] ?? "secondary"}>
+              {moderationLabels[detail.moderationStatus] ?? detail.moderationStatus}
+            </Badge>
+            <Badge variant={visibilityVariants[detail.visibility] ?? "secondary"}>
+              {visibilityLabels[detail.visibility] ?? detail.visibility}
+            </Badge>
+          </div>
+          <div className="grid gap-2 text-sm text-muted-foreground sm:grid-cols-2">
+            <div>
+              <span className="font-medium text-foreground">مالک:</span> {detail.owner.email ?? detail.owner.id}
+            </div>
+            <div>
+              <span className="font-medium text-foreground">شناسه کاربر:</span> {detail.owner.id}
+            </div>
+            <div>
+              <span className="font-medium text-foreground">تاریخ ایجاد:</span> {dateTimeFormatter.format(new Date(detail.createdAt))}
+            </div>
+            <div>
+              <span className="font-medium text-foreground">آخرین به‌روزرسانی:</span> {dateTimeFormatter.format(new Date(detail.updatedAt))}
+            </div>
+            {detail.moderationReviewedAt ? (
+              <div>
+                <span className="font-medium text-foreground">تاریخ بررسی:</span> {dateTimeFormatter.format(new Date(detail.moderationReviewedAt))}
+              </div>
+            ) : null}
+            {detail.moderationReviewedBy ? (
+              <div>
+                <span className="font-medium text-foreground">بررسی توسط:</span> {detail.moderationReviewedBy.email ?? detail.moderationReviewedBy.id}
+              </div>
+            ) : null}
+          </div>
+          {detail.errorMessage ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-destructive">
+              آخرین خطا: {detail.errorMessage}
+            </div>
+          ) : null}
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-base font-semibold text-foreground">اطلاعات فنی</h3>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <span className="text-muted-foreground">مدت زمان:</span> {formatDuration(detail.durationSec)}
+            </div>
+            <div>
+              <span className="text-muted-foreground">رزولوشن:</span>{" "}
+              {detail.width && detail.height ? `${numberFormatter.format(detail.width)}×${numberFormatter.format(detail.height)}` : "نامشخص"}
+            </div>
+            <div>
+              <span className="text-muted-foreground">کدک:</span> {detail.codec ?? "نامشخص"}
+            </div>
+            <div>
+              <span className="text-muted-foreground">بیت‌ریت:</span> {formatBitrate(detail.bitrate)}
+            </div>
+            <div>
+              <span className="text-muted-foreground">حجم فایل:</span> {formatSize(detail.sizeBytes)}
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-base font-semibold text-foreground">کلیدها</h3>
+          <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3 text-xs">
+            <div className="flex flex-col gap-1 break-all">
+              <span className="text-muted-foreground">سورس:</span>
+              <code className="font-mono">{detail.sourceKey}</code>
+            </div>
+            {detail.outputKey ? (
+              <div className="flex flex-col gap-1 break-all">
+                <span className="text-muted-foreground">خروجی:</span>
+                <code className="font-mono">{detail.outputKey}</code>
+              </div>
+            ) : null}
+            {detail.posterKey ? (
+              <div className="flex flex-col gap-1 break-all">
+                <span className="text-muted-foreground">پوستر:</span>
+                <code className="font-mono">{detail.posterKey}</code>
+              </div>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-base font-semibold text-foreground">اطلاعات تراسکد</h3>
+          {detail.lastJob ? (
+            <div className="space-y-2 rounded-md border border-border p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant={jobStatusVariants[detail.lastJob.status] ?? "secondary"}>
+                  {jobStatusLabels[detail.lastJob.status] ?? detail.lastJob.status}
+                </Badge>
+                <span className="text-xs text-muted-foreground">تلاش #{numberFormatter.format(detail.lastJob.attempt)}</span>
+              </div>
+              <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+                <div>
+                  شروع: {detail.lastJob.startedAt ? dateTimeFormatter.format(new Date(detail.lastJob.startedAt)) : "نامشخص"}
+                </div>
+                <div>
+                  پایان: {detail.lastJob.finishedAt ? dateTimeFormatter.format(new Date(detail.lastJob.finishedAt)) : "نامشخص"}
+                </div>
+              </div>
+              <div className="mt-2 max-h-48 overflow-auto rounded-md bg-muted/30 p-2 text-xs">
+                <pre className="whitespace-pre-wrap break-words">{renderLogs(detail.lastJob.logs)}</pre>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">هیچ تراسکدی ثبت نشده است.</p>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <Label htmlFor="moderation-reason" className="text-sm font-semibold text-foreground">
+            دلیل رد کردن
+          </Label>
+          <Textarea
+            id="moderation-reason"
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+            placeholder="در صورت رد رسانه، دلیل را اینجا ثبت کنید"
+            className="min-h-[96px]"
+          />
+        </section>
+
+        <section className="flex flex-wrap gap-2">
+          <Button onClick={handleRequeue} disabled={pendingAction} variant="outline" className="gap-2">
+            <RefreshCw className="h-4 w-4" /> صف مجدد ترنسکد
+          </Button>
+          <Button onClick={handleApprove} disabled={pendingAction || detail.moderationStatus === "approved"} className="bg-emerald-600 text-white hover:bg-emerald-700">
+            تایید
+          </Button>
+          <Button onClick={handleReject} disabled={pendingAction} variant="destructive" className="gap-2">
+            رد کردن
+          </Button>
+          <Button onClick={handleToggleVisibility} disabled={pendingAction} variant="outline" className="gap-2">
+            {detail.visibility === "public" ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+            تغییر نمایش
+          </Button>
+          <Button onClick={handleDelete} disabled={pendingAction} variant="destructive" className="gap-2">
+            <Trash2 className="h-4 w-4" /> حذف
+          </Button>
+        </section>
+      </div>
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl space-y-4" dir="rtl">
+        <DialogHeader className="space-y-1 text-right">
+          <DialogTitle>جزئیات رسانه</DialogTitle>
+          {detail ? <DialogDescription className="text-xs">شناسه رسانه: {detail.id}</DialogDescription> : null}
+        </DialogHeader>
+        {renderContent()}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/admin/media/AdminMediaStats.tsx
+++ b/apps/web/components/admin/media/AdminMediaStats.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const numberFormatter = new Intl.NumberFormat("fa-IR");
+const dateFormatter = new Intl.DateTimeFormat("fa-IR", { month: "short", day: "numeric" });
+
+type MediaMetricsResponse = {
+  totals: {
+    videos: number;
+    images: number;
+    ready: number;
+    failed: number;
+    pendingModeration: number;
+  };
+  last7Days: {
+    date: string;
+    uploads: number;
+    ready: number;
+    failed: number;
+  }[];
+};
+
+const LoadingState = () => {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Card key={index} className="p-4">
+          <Skeleton className="h-6 w-1/3" />
+          <Skeleton className="mt-4 h-9 w-2/3" />
+          <Skeleton className="mt-2 h-5 w-1/2" />
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+const ErrorState = ({ message }: { message: string }) => {
+  return (
+    <Card className="border-destructive/40 bg-destructive/10 p-6 text-destructive">
+      <CardHeader className="p-0">
+        <CardTitle className="text-lg">خطا در دریافت آمار</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0 pt-3 text-sm">{message}</CardContent>
+    </Card>
+  );
+};
+
+const SummaryCard = ({
+  title,
+  value,
+  subtitle,
+}: {
+  title: string;
+  value: number;
+  subtitle?: string;
+}) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold text-muted-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="text-3xl font-bold">{numberFormatter.format(value)}</div>
+        {subtitle ? <div className="text-xs text-muted-foreground">{subtitle}</div> : null}
+      </CardContent>
+    </Card>
+  );
+};
+
+const TrendCard = ({ data }: { data: MediaMetricsResponse["last7Days"] }) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold text-muted-foreground">۷ روز اخیر</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {data.length === 0 ? (
+          <p className="text-sm text-muted-foreground">داده‌ای برای نمایش وجود ندارد.</p>
+        ) : (
+          <div className="space-y-2">
+            {data.map((item) => (
+              <div key={item.date} className="flex items-center justify-between text-sm">
+                <div className="text-muted-foreground">{dateFormatter.format(new Date(item.date))}</div>
+                <div className="flex items-center gap-3">
+                  <span className="text-foreground">{numberFormatter.format(item.uploads)} آپلود</span>
+                  <span className="text-emerald-600">{numberFormatter.format(item.ready)} آماده</span>
+                  <span className="text-destructive">{numberFormatter.format(item.failed)} ناموفق</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export function AdminMediaStats() {
+  const [metrics, setMetrics] = useState<MediaMetricsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const response = await fetch("/api/admin/media/metrics", {
+          cache: "no-store",
+        });
+        if (!response.ok) {
+          throw new Error("پاسخ نامعتبر از سرور دریافت شد.");
+        }
+        const body = (await response.json()) as MediaMetricsResponse;
+        if (!cancelled) {
+          setMetrics(body);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "خطای ناشناخته رخ داد.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    return <ErrorState message={error} />;
+  }
+
+  if (!metrics) {
+    return <ErrorState message="داده‌ای دریافت نشد." />;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <SummaryCard
+        title="کل ویدیوها"
+        value={metrics.totals.videos}
+        subtitle={`تصاویر: ${numberFormatter.format(metrics.totals.images)}`}
+      />
+      <SummaryCard
+        title="آماده برای پخش"
+        value={metrics.totals.ready}
+        subtitle={`ناموفق: ${numberFormatter.format(metrics.totals.failed)}`}
+      />
+      <SummaryCard
+        title="در انتظار بررسی"
+        value={metrics.totals.pendingModeration}
+        subtitle="محتواهایی که نیاز به تایید دارند"
+      />
+      <TrendCard data={metrics.last7Days} />
+    </div>
+  );
+}

--- a/apps/web/components/admin/media/AdminMediaTable.tsx
+++ b/apps/web/components/admin/media/AdminMediaTable.tsx
@@ -1,0 +1,616 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Eye, EyeOff, Image as ImageIcon, MoreHorizontal, Video, RefreshCw, Trash2 } from "lucide-react";
+
+import { AdminMediaDetail } from "@/components/admin/media/AdminMediaDetail";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+
+const STATUS_OPTIONS = [
+  { value: "all", label: "همه وضعیت‌ها" },
+  { value: "uploaded", label: "آپلود شده" },
+  { value: "processing", label: "در حال پردازش" },
+  { value: "ready", label: "آماده" },
+  { value: "failed", label: "ناموفق" },
+] as const;
+
+const TYPE_OPTIONS = [
+  { value: "all", label: "همه نوع‌ها" },
+  { value: "video", label: "ویدیو" },
+  { value: "image", label: "تصویر" },
+] as const;
+
+const MODERATION_OPTIONS = [
+  { value: "all", label: "همه" },
+  { value: "pending", label: "در انتظار بررسی" },
+  { value: "approved", label: "تایید شده" },
+  { value: "rejected", label: "رد شده" },
+] as const;
+
+const statusLabels: Record<string, string> = {
+  uploaded: "آپلود شده",
+  processing: "در حال پردازش",
+  ready: "آماده",
+  failed: "ناموفق",
+};
+
+const statusVariants: Record<string, "secondary" | "warning" | "success" | "destructive"> = {
+  uploaded: "secondary",
+  processing: "warning",
+  ready: "success",
+  failed: "destructive",
+};
+
+const moderationLabels: Record<string, string> = {
+  pending: "در انتظار بررسی",
+  approved: "تایید شده",
+  rejected: "رد شده",
+};
+
+const moderationVariants: Record<string, "secondary" | "warning" | "success" | "destructive"> = {
+  pending: "warning",
+  approved: "success",
+  rejected: "destructive",
+};
+
+const visibilityLabels: Record<string, string> = {
+  public: "عمومی",
+  private: "خصوصی",
+};
+
+const visibilityVariants: Record<string, "success" | "secondary"> = {
+  public: "success",
+  private: "secondary",
+};
+
+type StatusFilter = (typeof STATUS_OPTIONS)[number]["value"];
+type TypeFilter = (typeof TYPE_OPTIONS)[number]["value"];
+type ModerationFilter = (typeof MODERATION_OPTIONS)[number]["value"];
+
+type FilterState = {
+  status: StatusFilter;
+  type: TypeFilter;
+  moderation: ModerationFilter;
+  user: string;
+};
+
+type AdminMediaListItem = {
+  id: string;
+  type: "image" | "video";
+  status: string;
+  visibility: "public" | "private";
+  moderationStatus: "pending" | "approved" | "rejected";
+  ownerUserId: string;
+  ownerEmail?: string | null;
+  createdAt: string;
+  durationSec?: number | null;
+  width?: number | null;
+  height?: number | null;
+  sizeBytes?: number | null;
+  errorMessage?: string | null;
+};
+
+type AdminMediaListResponse = {
+  items: AdminMediaListItem[];
+  nextCursor?: string | null;
+};
+
+type AdminMediaAction =
+  | { type: "REQUEUE_TRANSCODE"; mediaId: string }
+  | { type: "MARK_REJECTED"; mediaId: string; reason?: string }
+  | { type: "TOGGLE_VISIBILITY"; mediaId: string; visibility: "public" | "private" }
+  | { type: "DELETE_MEDIA"; mediaId: string };
+
+const numberFormatter = new Intl.NumberFormat("fa-IR");
+const dateTimeFormatter = new Intl.DateTimeFormat("fa-IR", { dateStyle: "medium", timeStyle: "short" });
+
+const formatDuration = (value: number | null | undefined) => {
+  if (!value || value <= 0) {
+    return "-";
+  }
+  const minutes = Math.floor(value / 60);
+  const seconds = value % 60;
+  return `${numberFormatter.format(minutes)}:${`${seconds}`.padStart(2, "0")}`;
+};
+
+const formatResolution = (width: number | null | undefined, height: number | null | undefined) => {
+  if (!width || !height) {
+    return "-";
+  }
+  return `${numberFormatter.format(width)}×${numberFormatter.format(height)}`;
+};
+
+const formatSize = (value: number | null | undefined) => {
+  if (!value || value <= 0) {
+    return "-";
+  }
+  const megabytes = value / (1024 * 1024);
+  const rounded = Math.round(megabytes * 10) / 10;
+  return `${numberFormatter.format(rounded)} مگابایت`;
+};
+
+export function AdminMediaTable() {
+  const { toast } = useToast();
+  const [filters, setFilters] = useState<FilterState>({ status: "all", type: "all", moderation: "all", user: "" });
+  const [items, setItems] = useState<AdminMediaListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [cursorHistory, setCursorHistory] = useState<Array<string | null>>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [selectedMediaId, setSelectedMediaId] = useState<string | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [actionPendingId, setActionPendingId] = useState<string | null>(null);
+  const [rejectTarget, setRejectTarget] = useState<{ mediaId: string; ownerEmail: string | null } | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const updateFilter = useCallback(<K extends keyof FilterState>(key: K, value: FilterState[K]) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+    setCursor(null);
+    setCursorHistory([]);
+  }, []);
+
+  const clearFilters = () => {
+    setFilters({ status: "all", type: "all", moderation: "all", user: "" });
+    setCursor(null);
+    setCursorHistory([]);
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        if (filters.status !== "all") {
+          params.set("status", filters.status);
+        }
+        if (filters.type !== "all") {
+          params.set("type", filters.type);
+        }
+        if (filters.moderation !== "all") {
+          params.set("moderation", filters.moderation);
+        }
+        if (filters.user.trim().length > 0) {
+          params.set("user", filters.user.trim());
+        }
+        if (cursor) {
+          params.set("cursor", cursor);
+        }
+        const response = await fetch(`/api/admin/media/list?${params.toString()}`, {
+          cache: "no-store",
+        });
+        if (!response.ok) {
+          throw new Error("خطایی در دریافت داده رخ داد.");
+        }
+        const body = (await response.json()) as AdminMediaListResponse;
+        if (cancelled) {
+          return;
+        }
+        setItems(body.items);
+        setNextCursor(body.nextCursor ?? null);
+      } catch (err) {
+        if (!cancelled) {
+          setItems([]);
+          setNextCursor(null);
+          setError(err instanceof Error ? err.message : "خطای ناشناخته رخ داد.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [filters, cursor, refreshKey]);
+
+  const performAction = useCallback(
+    async (payload: AdminMediaAction, successMessage: string) => {
+      setActionPendingId(payload.mediaId);
+      try {
+        const response = await fetch("/api/admin/media/actions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        const body = (await response.json()) as { ok: boolean; error?: string };
+        if (!response.ok || !body.ok) {
+          throw new Error(body.error ?? "عملیات ناموفق بود.");
+        }
+        toast({ title: successMessage });
+        setRefreshKey((prev) => prev + 1);
+        return true;
+      } catch (err) {
+        toast({ variant: "destructive", title: "خطا", description: err instanceof Error ? err.message : "عملیات ناموفق بود." });
+        return false;
+      } finally {
+        setActionPendingId(null);
+      }
+    },
+    [toast],
+  );
+
+  const handleRequeue = (mediaId: string) => {
+    performAction({ type: "REQUEUE_TRANSCODE", mediaId }, "رسانه برای پردازش مجدد در صف قرار گرفت.");
+  };
+
+  const handleToggleVisibility = (row: AdminMediaListItem) => {
+    const nextVisibility = row.visibility === "public" ? "private" : "public";
+    const message = nextVisibility === "public" ? "رسانه عمومی شد." : "رسانه خصوصی شد.";
+    performAction({ type: "TOGGLE_VISIBILITY", mediaId: row.id, visibility: nextVisibility }, message);
+  };
+
+  const handleDelete = (mediaId: string) => {
+    const confirmed = window.confirm("آیا از حذف این رسانه اطمینان دارید؟");
+    if (!confirmed) {
+      return;
+    }
+    performAction({ type: "DELETE_MEDIA", mediaId }, "رسانه حذف شد.");
+  };
+
+  const openRejectDialog = (row: AdminMediaListItem) => {
+    setRejectTarget({ mediaId: row.id, ownerEmail: row.ownerEmail ?? null });
+    setRejectReason("");
+  };
+
+  const confirmReject = async () => {
+    if (!rejectTarget) {
+      return;
+    }
+    const ok = await performAction(
+      { type: "MARK_REJECTED", mediaId: rejectTarget.mediaId, reason: rejectReason },
+      "رسانه با موفقیت رد شد.",
+    );
+    if (ok) {
+      setRejectTarget(null);
+      setRejectReason("");
+    }
+  };
+
+  const handleOwnerFilter = (value: string) => {
+    updateFilter("user", value);
+  };
+
+  const handleNextPage = () => {
+    if (!nextCursor) {
+      return;
+    }
+    setCursorHistory((prev) => [...prev, cursor]);
+    setCursor(nextCursor);
+  };
+
+  const handlePrevPage = () => {
+    setCursorHistory((prev) => {
+      if (prev.length === 0) {
+        setCursor(null);
+        return prev;
+      }
+      const previous = prev[prev.length - 1];
+      setCursor(previous);
+      return prev.slice(0, -1);
+    });
+  };
+
+  const openDetail = (mediaId: string) => {
+    setSelectedMediaId(mediaId);
+    setDetailOpen(true);
+  };
+
+  const handleDetailOpenChange = (open: boolean) => {
+    setDetailOpen(open);
+    if (!open) {
+      setSelectedMediaId(null);
+    }
+  };
+
+  const handleDetailActionComplete = () => {
+    setRefreshKey((prev) => prev + 1);
+  };
+
+  const hasPrev = cursorHistory.length > 0;
+  const hasNext = Boolean(nextCursor);
+
+  const rows = useMemo(() => items, [items]);
+
+  return (
+    <div className="space-y-6" dir="rtl">
+      <div className="flex flex-wrap items-center gap-3">
+        <Select value={filters.status} onValueChange={(value: StatusFilter) => updateFilter("status", value)}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="وضعیت" />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={filters.type} onValueChange={(value: TypeFilter) => updateFilter("type", value)}>
+          <SelectTrigger className="w-[140px]">
+            <SelectValue placeholder="نوع" />
+          </SelectTrigger>
+          <SelectContent>
+            {TYPE_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={filters.moderation} onValueChange={(value: ModerationFilter) => updateFilter("moderation", value)}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="وضعیت بررسی" />
+          </SelectTrigger>
+          <SelectContent>
+            {MODERATION_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Input
+          className="w-64"
+          placeholder="جستجوی ایمیل یا شناسه"
+          value={filters.user}
+          onChange={(event) => updateFilter("user", event.target.value)}
+        />
+
+        <Button variant="ghost" onClick={clearFilters} className="text-sm">
+          پاک‌سازی فیلترها
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-12 text-center">انتخاب</TableHead>
+              <TableHead className="w-16 text-center">نوع</TableHead>
+              <TableHead>وضعیت‌ها</TableHead>
+              <TableHead>نمایش</TableHead>
+              <TableHead>کاربر</TableHead>
+              <TableHead>تاریخ ایجاد</TableHead>
+              <TableHead>مدت / رزولوشن</TableHead>
+              <TableHead>حجم</TableHead>
+              <TableHead>آخرین خطا</TableHead>
+              <TableHead className="text-center">عملیات</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={10} className="py-10">
+                  <div className="flex justify-center">
+                    <Skeleton className="h-6 w-40" />
+                  </div>
+                </TableCell>
+              </TableRow>
+            ) : error ? (
+              <TableRow>
+                <TableCell colSpan={10} className="py-6 text-center text-sm text-destructive">
+                  {error}
+                </TableCell>
+              </TableRow>
+            ) : rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={10} className="py-6 text-center text-sm text-muted-foreground">
+                  رسانه‌ای برای نمایش وجود ندارد.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => {
+                const isPending = actionPendingId === row.id;
+                return (
+                  <TableRow key={row.id}>
+                    <TableCell className="text-center">
+                      <input type="checkbox" disabled className="h-4 w-4" />
+                    </TableCell>
+                    <TableCell className="text-center">
+                      {row.type === "video" ? (
+                        <Video className="mx-auto h-5 w-5 text-muted-foreground" />
+                      ) : (
+                        <ImageIcon className="mx-auto h-5 w-5 text-muted-foreground" />
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant={statusVariants[row.status] ?? "secondary"}>
+                          {statusLabels[row.status] ?? row.status}
+                        </Badge>
+                        <Badge variant={moderationVariants[row.moderationStatus] ?? "secondary"}>
+                          {moderationLabels[row.moderationStatus] ?? row.moderationStatus}
+                        </Badge>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={visibilityVariants[row.visibility] ?? "secondary"}>
+                        {visibilityLabels[row.visibility] ?? row.visibility}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col text-sm">
+                        {row.ownerEmail ? (
+                          <button
+                            type="button"
+                            className="text-right text-primary hover:underline"
+                            onClick={() => handleOwnerFilter(row.ownerEmail ?? "")}
+                          >
+                            {row.ownerEmail}
+                          </button>
+                        ) : (
+                          <span className="text-muted-foreground">بدون ایمیل</span>
+                        )}
+                        <span className="text-xs text-muted-foreground">{row.ownerUserId}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                      {dateTimeFormatter.format(new Date(row.createdAt))}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      <div>{formatDuration(row.durationSec ?? null)}</div>
+                      <div>{formatResolution(row.width ?? null, row.height ?? null)}</div>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">{formatSize(row.sizeBytes ?? null)}</TableCell>
+                    <TableCell className="max-w-xs text-sm text-muted-foreground">
+                      <span className="line-clamp-2 break-words">{row.errorMessage ?? "-"}</span>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center justify-end gap-2">
+                        <Button size="sm" variant="outline" onClick={() => openDetail(row.id)}>
+                          جزئیات
+                        </Button>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button size="icon" variant="ghost" disabled={isPending}>
+                              <MoreHorizontal className="h-4 w-4" />
+                              <span className="sr-only">باز کردن منو</span>
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" className="w-48">
+                            <DropdownMenuItem
+                              onSelect={(event) => {
+                                event.preventDefault();
+                                handleRequeue(row.id);
+                              }}
+                            >
+                              <RefreshCw className="ml-2 h-4 w-4" /> صف مجدد ترنسکد
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onSelect={(event) => {
+                                event.preventDefault();
+                                openRejectDialog(row);
+                              }}
+                            >
+                              رد کردن
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onSelect={(event) => {
+                                event.preventDefault();
+                                handleToggleVisibility(row);
+                              }}
+                            >
+                              {row.visibility === "public" ? (
+                                <EyeOff className="ml-2 h-4 w-4" />
+                              ) : (
+                                <Eye className="ml-2 h-4 w-4" />
+                              )}
+                              تغییر نمایش
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onSelect={(event) => {
+                                event.preventDefault();
+                                handleDelete(row.id);
+                              }}
+                            >
+                              <Trash2 className="ml-2 h-4 w-4" /> حذف
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-muted-foreground">
+          {rows.length > 0 ? `${numberFormatter.format(rows.length)} مورد نمایش داده می‌شود` : "بدون داده"}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={handlePrevPage} disabled={!hasPrev}>
+            قبلی
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleNextPage} disabled={!hasNext}>
+            بعدی
+          </Button>
+        </div>
+      </div>
+
+      <AdminMediaDetail
+        mediaId={selectedMediaId}
+        open={detailOpen}
+        onOpenChange={handleDetailOpenChange}
+        onActionComplete={handleDetailActionComplete}
+      />
+
+      <Dialog
+        open={Boolean(rejectTarget)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRejectTarget(null);
+            setRejectReason("");
+          }
+        }}
+      >
+        <DialogContent dir="rtl">
+          <DialogHeader className="space-y-1 text-right">
+            <DialogTitle>رد کردن رسانه</DialogTitle>
+            {rejectTarget?.ownerEmail ? (
+              <DialogDescription>برای کاربر {rejectTarget.ownerEmail}</DialogDescription>
+            ) : null}
+          </DialogHeader>
+          <div className="space-y-3">
+            <Label htmlFor="reject-reason">دلیل رد کردن</Label>
+            <Textarea
+              id="reject-reason"
+              value={rejectReason}
+              onChange={(event) => setRejectReason(event.target.value)}
+              placeholder="توضیح کوتاه درباره علت رد"
+              className="min-h-[120px]"
+            />
+          </div>
+          <DialogFooter className="justify-end gap-2">
+            <DialogClose asChild>
+              <Button variant="ghost">انصراف</Button>
+            </DialogClose>
+            <Button
+              onClick={confirmReject}
+              disabled={!rejectTarget || actionPendingId === rejectTarget.mediaId}
+              variant="destructive"
+            >
+              رد کردن
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-input bg-popover p-1 text-popover-foreground shadow-md animate-in slide-in-from-left-1",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-input bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+  return <span className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)} {...props} />;
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
+const DropdownMenuArrow = DropdownMenuPrimitive.Arrow;
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuArrow,
+  DropdownMenuRadioGroup,
+};

--- a/apps/web/lib/auth/admin.ts
+++ b/apps/web/lib/auth/admin.ts
@@ -1,0 +1,61 @@
+import type { User } from "@prisma/client";
+import type { Session } from "next-auth";
+
+import { getServerAuthSession } from "@/lib/auth/session";
+
+type UserLike = User | { role?: string; email?: string } | null | undefined;
+
+const adminEmailSet: Set<string> = (() => {
+  const raw = process.env.ADMIN_EMAILS;
+  if (!raw) {
+    return new Set();
+  }
+  const entries = raw
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+  return new Set(entries);
+})();
+
+const isAdminRole = (role: string | undefined): boolean => {
+  if (!role) {
+    return false;
+  }
+  return role.toUpperCase() === "ADMIN";
+};
+
+const isAdminEmail = (email: string | undefined | null): boolean => {
+  if (!email) {
+    return false;
+  }
+  return adminEmailSet.has(email.trim().toLowerCase());
+};
+
+export function isAdminUser(user: UserLike): boolean {
+  if (!user) {
+    return false;
+  }
+  const role = typeof user.role === "string" ? user.role : undefined;
+  if (isAdminRole(role)) {
+    return true;
+  }
+  const email = typeof user.email === "string" ? user.email : undefined;
+  if (isAdminEmail(email)) {
+    return true;
+  }
+  return false;
+}
+
+export async function requireAdminSession(): Promise<{
+  session: Session;
+  user: NonNullable<Session["user"]>;
+}> {
+  const session = await getServerAuthSession();
+  if (!session || !session.user) {
+    throw new Error("ADMIN_SESSION_REQUIRED");
+  }
+  if (!isAdminUser(session.user)) {
+    throw new Error("ADMIN_ACCESS_DENIED");
+  }
+  return { session, user: session.user };
+}

--- a/apps/web/lib/media/admin/metrics.ts
+++ b/apps/web/lib/media/admin/metrics.ts
@@ -1,0 +1,118 @@
+import type { PrismaClient } from "@prisma/client";
+
+type Last7DayEntry = {
+  date: string;
+  uploads: number;
+  ready: number;
+  failed: number;
+};
+
+type AdminMediaMetrics = {
+  totals: {
+    videos: number;
+    images: number;
+    ready: number;
+    failed: number;
+    pendingModeration: number;
+  };
+  last7Days: Last7DayEntry[];
+};
+
+const formatDateKey = (value: Date): string => {
+  const year = value.getFullYear();
+  const month = `${value.getMonth() + 1}`.padStart(2, "0");
+  const day = `${value.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const buildDateRange = (days: number): Date[] => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const range: Date[] = [];
+  for (let offset = days - 1; offset >= 0; offset -= 1) {
+    const date = new Date(today);
+    date.setDate(today.getDate() - offset);
+    range.push(date);
+  }
+  return range;
+};
+
+const normalizeRowValue = (value: unknown): number => {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+};
+
+export async function getAdminMediaMetrics(prisma: PrismaClient): Promise<AdminMediaMetrics> {
+  const [videos, images, ready, failed, pendingModeration] = await Promise.all([
+    prisma.mediaAsset.count({ where: { type: "video" } }),
+    prisma.mediaAsset.count({ where: { type: "image" } }),
+    prisma.mediaAsset.count({ where: { status: "ready" } }),
+    prisma.mediaAsset.count({ where: { status: "failed" } }),
+    prisma.mediaAsset.count({ where: { moderationStatus: "pending" } }),
+  ]);
+
+  const startDate = new Date();
+  startDate.setHours(0, 0, 0, 0);
+  startDate.setDate(startDate.getDate() - 6);
+
+  const rawRows = await prisma.$queryRaw<Array<{ date: Date; uploads: unknown; ready: unknown; failed: unknown }>>`
+    SELECT
+      DATE("createdAt") AS date,
+      COUNT(*) AS uploads,
+      COUNT(*) FILTER (WHERE "status" = 'ready') AS ready,
+      COUNT(*) FILTER (WHERE "status" = 'failed') AS failed
+    FROM "MediaAsset"
+    WHERE "createdAt" >= ${startDate}
+    GROUP BY DATE("createdAt")
+    ORDER BY DATE("createdAt")
+  `;
+
+  const range = buildDateRange(7);
+  const statsMap = new Map<string, Last7DayEntry>();
+  for (const date of range) {
+    const key = formatDateKey(date);
+    statsMap.set(key, { date: key, uploads: 0, ready: 0, failed: 0 });
+  }
+
+  for (const row of rawRows) {
+    const key = formatDateKey(row.date);
+    const entry = statsMap.get(key);
+    if (!entry) {
+      continue;
+    }
+    entry.uploads = normalizeRowValue(row.uploads);
+    entry.ready = normalizeRowValue(row.ready);
+    entry.failed = normalizeRowValue(row.failed);
+  }
+
+  const last7Days = range.map((date) => statsMap.get(formatDateKey(date)) ?? {
+    date: formatDateKey(date),
+    uploads: 0,
+    ready: 0,
+    failed: 0,
+  });
+
+  return {
+    totals: {
+      videos,
+      images,
+      ready,
+      failed,
+      pendingModeration,
+    },
+    last7Days,
+  };
+}
+
+export type { AdminMediaMetrics };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,7 +36,8 @@
     "storage:smoke:original": "tsx scripts/storage/put-and-get-original.ts",
     "storage:smoke:signed-expiry": "tsx scripts/storage/signed-url-expiry-check.ts",
     "storage:smoke:visibility": "tsx scripts/storage/visibility-routing-check.ts",
-    "media:cdn-url-check": "tsx scripts/media/cdn-url-check.mts"
+    "media:cdn-url-check": "tsx scripts/media/cdn-url-check.mts",
+    "admin:media-metrics": "tsx scripts/admin/media-metrics-check.mts"
   },
   "dependencies": {
     "@acme/contracts": "workspace:*",

--- a/apps/web/prisma/migrations/sprint8_media_moderation/migration.sql
+++ b/apps/web/prisma/migrations/sprint8_media_moderation/migration.sql
@@ -1,0 +1,15 @@
+-- CreateEnum
+CREATE TYPE "MediaModerationStatus" AS ENUM ('pending', 'approved', 'rejected');
+
+-- AlterTable
+ALTER TABLE "MediaAsset"
+ADD COLUMN     "moderationStatus" "MediaModerationStatus" NOT NULL DEFAULT 'pending',
+ADD COLUMN     "moderationReason" TEXT,
+ADD COLUMN     "moderationReviewedAt" TIMESTAMP(3),
+ADD COLUMN     "moderationReviewedById" TEXT;
+
+-- CreateIndex
+CREATE INDEX "MediaAsset_moderationStatus_idx" ON "MediaAsset"("moderationStatus");
+
+-- AddForeignKey
+ALTER TABLE "MediaAsset" ADD CONSTRAINT "MediaAsset_moderationReviewedById_fkey" FOREIGN KEY ("moderationReviewedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   notificationPreferences NotificationPreference[]
   notificationMessageLogs NotificationMessageLog[]
   mediaAssets             MediaAsset[]
+  mediaModerationReviews  MediaAsset[]            @relation("MediaModerationReviewer")
 }
 
 model Profile {
@@ -450,13 +451,19 @@ model MediaAsset {
   bitrate       Int?
   sizeBytes     BigInt?
   errorMessage  String?
+  moderationStatus      MediaModerationStatus @default(pending)
+  moderationReason      String?
+  moderationReviewedAt  DateTime?
+  moderationReviewedById String?
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt
   owner         User            @relation(fields: [ownerUserId], references: [id], onDelete: Cascade)
+  moderationReviewedBy  User?            @relation("MediaModerationReviewer", fields: [moderationReviewedById], references: [id])
   transcodeJobs TranscodeJob[]
 
   @@index([ownerUserId, type, status])
   @@index([createdAt])
+  @@index([moderationStatus])
 }
 
 model TranscodeJob {
@@ -618,6 +625,12 @@ enum MediaStatus {
 enum MediaVisibility {
   public
   private
+}
+
+enum MediaModerationStatus {
+  pending
+  approved
+  rejected
 }
 
 enum TranscodeJobStatus {

--- a/apps/web/scripts/admin/media-metrics-check.mts
+++ b/apps/web/scripts/admin/media-metrics-check.mts
@@ -1,0 +1,63 @@
+import "../storage/env-loader";
+
+import { PrismaClient } from "@prisma/client";
+
+import { getAdminMediaMetrics } from "../../lib/media/admin/metrics";
+
+const prisma = new PrismaClient();
+
+const assertTotals = (totals: Record<string, unknown>) => {
+  const keys = ["videos", "images", "ready", "failed", "pendingModeration"] as const;
+  for (const key of keys) {
+    const value = totals[key];
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      throw new Error(`Invalid totals.${key} value: ${value}`);
+    }
+  }
+};
+
+const assertLast7Days = (entries: Array<Record<string, unknown>>) => {
+  if (!Array.isArray(entries)) {
+    throw new Error("last7Days must be an array");
+  }
+  for (const entry of entries) {
+    const date = entry.date;
+    const uploads = entry.uploads;
+    const ready = entry.ready;
+    const failed = entry.failed;
+    if (typeof date !== "string" || date.length === 0) {
+      throw new Error(`Invalid last7Days.date value: ${date}`);
+    }
+    for (const [key, value] of [
+      ["uploads", uploads],
+      ["ready", ready],
+      ["failed", failed],
+    ] as const) {
+      if (typeof value !== "number" || Number.isNaN(value)) {
+        throw new Error(`Invalid last7Days.${key} value: ${value}`);
+      }
+    }
+  }
+};
+
+async function run() {
+  const metrics = await getAdminMediaMetrics(prisma);
+  assertTotals(metrics.totals as Record<string, unknown>);
+  assertLast7Days(metrics.last7Days as Array<Record<string, unknown>>);
+
+  console.log("Media totals:");
+  console.log(JSON.stringify(metrics.totals, null, 2));
+  console.log("\nLast 7 days:");
+  for (const entry of metrics.last7Days) {
+    console.log(`${entry.date} → uploads=${entry.uploads}, ready=${entry.ready}, failed=${entry.failed}`);
+  }
+}
+
+run()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/docs/video/phase8-admin-moderation.md
+++ b/docs/video/phase8-admin-moderation.md
@@ -1,0 +1,43 @@
+# Phase 8 – Admin Media Moderation
+
+## Overview
+The `/admin/media` dashboard allows operations staff to review every uploaded media asset. The page enforces admin-only access and surfaces moderation state, processing progress, and visibility for both videos and images. From this screen, admins can filter, inspect details, and trigger remediation actions without leaving the workflow.
+
+## Filters & Listing
+* **Status** – آپلود شده، در حال پردازش، آماده، ناموفق.
+* **Type** – ویدیو یا تصویر.
+* **Moderation** – در انتظار بررسی، تایید شده، رد شده.
+* **User search** – جستجو بر اساس ایمیل یا شناسه مالک.
+
+Results are ordered by `createdAt` (latest first) with cursor-based pagination. Each row shows type, processing status, moderation badge, visibility, owner info, duration/resolution, size, and the latest error if present.
+
+## Row Actions
+Use the سه‌نقطه menu or the detail view to run server-side admin actions:
+
+| Action | Behavior |
+| --- | --- |
+| صف مجدد ترنسکد | ایجاد تلاش جدید در صف BullMQ و تغییر وضعیت به processing. |
+| رد کردن | ثبت `moderationStatus = rejected` به همراه دلیل و خصوصی کردن رسانه. |
+| تغییر نمایش | جابه‌جایی بین عمومی/خصوصی. وقتی رسانه عمومی می‌شود، به‌صورت خودکار `approved` می‌گردد. |
+| حذف | حذف ردیف MediaAsset، کارهای ترنسکد مرتبط و تلاش برای پاکسازی فایل‌های S3. |
+
+## Detail Panel
+Selecting **جزئیات** opens a modal with:
+
+* وضعیت پردازش، moderation، و نمایش به همراه زمان‌بندی بررسی و نام ادمین.
+* مشخصات فنی (مدت، رزولوشن، کدک، بیت‌ریت، حجم) و کلیدهای ذخیره‌سازی.
+* آخرین `TranscodeJob` شامل وضعیت، تلاش، زمان شروع/پایان و لاگ‌ها.
+* فرم «دلیل رد کردن» برای ثبت یا ویرایش توضیح.
+* دکمه‌های اقدام سریع (صف مجدد، تایید، رد، تغییر نمایش، حذف).
+
+## Moderation Lifecycle
+1. بارگذاری جدید → `moderationStatus = pending` و `visibility = private`.
+2. تغییر نمایش به عمومی → سیستم `moderationStatus` را به `approved` تنظیم می‌کند و برچسب بررسی را با ادمین ثبت می‌نماید.
+3. رد کردن → وضعیت به `rejected`، دلیل ذخیره می‌شود، تاریخ/ادمین بررسی ثبت و رسانه خصوصی می‌گردد.
+4. حذف → تمام داده‌ها و خروجی‌های پردازش پاک می‌شود.
+
+## Metrics Endpoint & Script
+* **GET `/api/admin/media/metrics`** – بازگشت آمار کلی (تعداد ویدیوها/تصاویر، آماده، ناموفق، موارد در انتظار بررسی) و روند ۷ روز اخیر (آپلودها، آماده، ناموفق).
+* **Script** – `pnpm --filter @app/web admin:media-metrics` مستقیماً Prisma را اجرا می‌کند، پاسخ را لاگ و ساختار را اعتبارسنجی می‌نماید.
+
+این مرحله ابزارهای لازم برای پایش روزانه و رسیدگی سریع به مشکلات پردازش یا تصمیم‌های moderation را فراهم می‌کند.


### PR DESCRIPTION
## Summary
- extend the Prisma schema with media moderation fields and migrations
- add admin-only media APIs for listing, actions, metrics, and detail retrieval plus shared metrics helper
- build the /admin/media interface with stats, table, detail panel, dropdown menu component, and supporting docs/script

## Testing
- pnpm --filter @app/web lint *(fails: unable to download pnpm package due to proxy error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d5fe97c88327aa339c69ea4e676e)